### PR TITLE
Tune rate limiter

### DIFF
--- a/changelogs/unreleased/51-bryanl
+++ b/changelogs/unreleased/51-bryanl
@@ -1,0 +1,4 @@
+Tune rate limiter
+
+* Tune rate limiter for client-go's rest client
+* rename item referred to as restClient to restConfig (as it's a config and not a client)

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -264,6 +264,8 @@ func FromKubeConfig(ctx context.Context, kubeconfig, contextName string) (*Clust
 		return nil, err
 	}
 
+	config = withConfigDefaults(config)
+
 	return newCluster(ctx, cc, config)
 }
 
@@ -271,6 +273,8 @@ func FromKubeConfig(ctx context.Context, kubeconfig, contextName string) (*Clust
 // See core_client.go#setConfigDefaults
 func withConfigDefaults(inConfig *rest.Config) *rest.Config {
 	config := rest.CopyConfig(inConfig)
+	config.QPS = 30
+	config.Burst = 100
 	config.APIPath = "/api"
 	if config.GroupVersion == nil || config.GroupVersion.Group != scheme.Scheme.PrioritizedVersionsForGroup("")[0].Group {
 		gv := scheme.Scheme.PrioritizedVersionsForGroup("")[0]

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -63,7 +63,7 @@ type RESTInterface interface {
 // Cluster is a client for cluster operations
 type Cluster struct {
 	clientConfig clientcmd.ClientConfig
-	restClient   *rest.Config
+	restConfig   *rest.Config
 	logger       log.Logger
 
 	kubernetesClient kubernetes.Interface
@@ -116,7 +116,7 @@ func newCluster(ctx context.Context, clientConfig clientcmd.ClientConfig, restCl
 
 	c := &Cluster{
 		clientConfig:     clientConfig,
-		restClient:       restClient,
+		restConfig:       restClient,
 		kubernetesClient: kubernetesClient,
 		dynamicClient:    dynamicClient,
 		discoveryClient:  discoveryClient,
@@ -225,13 +225,13 @@ func (c *Cluster) InfoClient() (InfoInterface, error) {
 
 // RESTClient returns a RESTClient for the cluster.
 func (c *Cluster) RESTClient() (rest.Interface, error) {
-	config := withConfigDefaults(c.restClient)
+	config := withConfigDefaults(c.restConfig)
 	return rest.RESTClientFor(config)
 }
 
 // RESTConfig returns configuration for communicating with the cluster.
 func (c *Cluster) RESTConfig() *rest.Config {
-	return c.restClient
+	return c.restConfig
 }
 
 // Version returns a ServerVersion for the cluster.


### PR DESCRIPTION
* Tune rate limiter for client-go's rest client
* rename item referred to as `restClient` to `restConfig` (as it's a config and not a client)