### PR TITLE
Preserve view during a namespace switch

### DIFF
--- a/changelogs/unreleased/80-mdaverde
+++ b/changelogs/unreleased/80-mdaverde
@@ -1,0 +1,1 @@
+Preserve resource view during a namespace switch

--- a/web/src/app/util/includesArray.spec.ts
+++ b/web/src/app/util/includesArray.spec.ts
@@ -1,0 +1,19 @@
+import { includesArray } from './includesArray';
+
+describe('includesArray', () => {
+  it('should return false if second param array is larger', () => {
+    expect(includesArray(['a', 'b', 'c'], ['a', 'b', 'c', 'd'])).toBe(false);
+  });
+
+  it('should return true if second array is included in first array', () => {
+    expect(includesArray(['a', 'b', 'c', 'd'], ['a', 'b', 'c'])).toBe(true);
+  });
+
+  it('should return false if second array is not included in first array', () => {
+    expect(includesArray(['a', 'b', 'c', 'd'], ['a', 'e', 'c'])).toBe(false);
+  });
+
+  it('should return false if unordered second array is not included in first array', () => {
+    expect(includesArray(['a', 'b', 'c', 'd'], ['a', 'c', 'b'])).toBe(false);
+  });
+});

--- a/web/src/app/util/includesArray.ts
+++ b/web/src/app/util/includesArray.ts
@@ -1,0 +1,13 @@
+export function includesArray(arrA: string[], arrB: string[]): boolean {
+  if (arrA.length < arrB.length) {
+    return false;
+  }
+
+  for (let i = 0; i < arrB.length; i++) {
+    if (arrA[i] !== arrB[i]) {
+      return false;
+    }
+  }
+
+  return true;
+}


### PR DESCRIPTION
When switching namespaces while looking at a specific resource, a user expects to stay on that resource but still change namespaces. Because our navigation is dynamic, this makes it tricky to determine if the same navigation options are available in the next namespace (such as CRDs).

If a user is on a non-namespace-scoped view (cluster-scoped CRDs or the configuration page) and they switch namespaces, the UI will take the user to that namespace's Overview page.

Adds a new util function.

Relates to Issue #73 