### PR TITLE
Fix spelling of GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Feature requests, bug reports, and enhancements are welcome. Contributors, maint
 
  - [Twitter](https://twitter.com/projectoctant)
  - [Google group](https://groups.google.com/forum/#!forum/project-octant/)
- - [Github issues](https://github.com/vmware/octant/issues)
+ - [GitHub issues](https://github.com/vmware/octant/issues)
 
 ## Contributing
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -6,15 +6,15 @@
 
 2. Pull the change then run `make release`
 
-3. A new build will be triggered then a draft of the artifacts will be available for review in Github Releases.
+3. A new build will be triggered then a draft of the artifacts will be available for review in GitHub Releases.
 
 ### Encrypt a token
 
 1. Download the Travis CLI ruby gem: `gem install travis`
 
-2. Login with your Github account: `travis login --pro`.
+2. Login with your GitHub account: `travis login --pro`.
 
-3. Generate the token through the heptibot Github account. Navigate to the project root and encrypt the token: `travis encrypt GITHUB_TOKEN="..." --add`. The token can only be decrypted by Travis CI, not the encrypter or owners of the repository.
+3. Generate the token through the heptibot GitHub account. Navigate to the project root and encrypt the token: `travis encrypt GITHUB_TOKEN="..." --add`. The token can only be decrypted by Travis CI, not the encrypter or owners of the repository.
 
 4. Commit the changes to `.travis.yml` and push.
 
@@ -22,7 +22,7 @@
 
 What you'll need:
 
- - a Github token with repo scope enabled
+ - a GitHub token with repo scope enabled
  - an installation of rpmbuild
  - an installation of [goreleaser](https://goreleaser.com)
 


### PR DESCRIPTION
I hate to be pedantic about this, just did a find and replace for `Github` and changed it to `GitHub`. Congrats on the release!