### PR TITLE
[docs] getting-started: fix readme+drone links

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,6 +26,6 @@ These build tools can be installed via Makefile with `make go-install`.
 
 A development binary can be built by `make octant-dev`.
 
-For UI changes, see the [README](web/README.md) located in `web/`.
+For UI changes, see the [README](/web/README.md) located in `web/`.
 
-If Docker and [Drone](docs/drone.md) are installed, tests and build steps can run in a containerized environment.
+If Docker and [Drone](/docs/drone.md) are installed, tests and build steps can run in a containerized environment.


### PR DESCRIPTION
Hey folks, I ran into some broken links while navigating the docs (the [Drone link](https://github.com/vmware/octant/blob/master/docs/docs/drone.md) as is 404'd) and thought I'd fix the link.

Thanks for releasing Octant, really looking forward to getting started with it!