### PR TITLE
Update README with launch expectation detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Start running Octant:
 
 `$ octant`
 
+Octant should immediately launch your default web browser to an available high level port on 127.0.0.1. (i.e. http://127.0.0.1:51234)
+
 For configuring Octant, setting up a development environment, or running tests, refer to the documentation [here](docs/getting-started.md).
 
 ## Plugins


### PR DESCRIPTION
It's good to set expectations =)
The first few times I ran 'octant' it didn't open a browser, or opened one in the background. I looked to see which port it would launch on, thinking I had to go to the URL manually, but couldn't find it in the docs... so after getting it to work (by just trying a few more times), I realized it launches on a different port each time.  Just thought it would help someone else get started by setting the expectation with what happens after one types 'octant' and hits Return.