### PR TITLE
Update sample plugin location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ ci-quick:
 install-test-plugin:
 	@echo $(OCTANT_PLUGINSTUB_DIR)
 	mkdir -p $(OCTANT_PLUGINSTUB_DIR)
-	go build -o $(OCTANT_PLUGINSTUB_DIR)/pluginstub github.com/vmware/octant/cmd/pluginstub
+	go build -o $(OCTANT_PLUGINSTUB_DIR)/octant-sample-plugin github.com/vmware/octant/cmd/octant-sample-plugin
 
 .PHONY:
 build-deps:

--- a/docs/plugins/content/docs/writing-plugins.md
+++ b/docs/plugins/content/docs/writing-plugins.md
@@ -53,7 +53,7 @@ will pass in the name and description for the plugin.
 
 ## Example
 
-Octant ships with an [example plugin](https://github.com/vmware/octant/cmd/pluginstub/main.go).
+Octant ships with an [example plugin](https://github.com/vmware/octant/blob/master/cmd/octant-sample-plugin/main.go).
 
 # More About Capabilities
 


### PR DESCRIPTION
PR fixes `install-test-plugin` target and updates the sample plugin main.go URL in the documentation. 