### PR TITLE
Support multiple kubeconfig files

### DIFF
--- a/changelogs/unreleased/164-bryanl
+++ b/changelogs/unreleased/164-bryanl
@@ -1,0 +1,1 @@
+Support multiple kubeconfig files

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/pkg/errors"
@@ -27,6 +28,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/vmware/octant/internal/log"
+	"github.com/vmware/octant/internal/util/strings"
 
 	// auth plugins
 	_ "k8s.io/client-go/plugin/pkg/client/auth/azure"
@@ -249,9 +251,10 @@ func (c *Cluster) Version() (string, error) {
 
 // FromKubeConfig creates a Cluster from a kubeConfig.
 func FromKubeConfig(ctx context.Context, kubeConfig, contextName string, options RESTConfigOptions) (*Cluster, error) {
-	rules := clientcmd.NewDefaultClientConfigLoadingRules()
-	if kubeConfig != "" {
-		rules.ExplicitPath = kubeConfig
+	chain := strings.Deduplicate(filepath.SplitList(kubeConfig))
+
+	rules := &clientcmd.ClientConfigLoadingRules{
+		Precedence: chain,
 	}
 
 	overrides := &clientcmd.ConfigOverrides{}

--- a/internal/commands/dash.go
+++ b/internal/commands/dash.go
@@ -114,7 +114,10 @@ func newOctantCmd() *cobra.Command {
 	octantCmd.Flags().Float32VarP(&clientQPS, "client-qps", "", 200, "maximum QPS for client")
 	octantCmd.Flags().IntVarP(&clientBurst, "client-burst", "", 400, "maximum burst for client throttle")
 
-	kubeConfig = clientcmd.NewDefaultClientConfigLoadingRules().GetDefaultFilename()
+	kubeConfig = os.Getenv("KUBECONFIG")
+	if kubeConfig == "" {
+		kubeConfig = clientcmd.NewDefaultClientConfigLoadingRules().GetDefaultFilename()
+	}
 
 	octantCmd.Flags().StringVar(&kubeConfig, "kubeconfig", kubeConfig, "absolute path to kubeConfig file")
 

--- a/internal/kubeconfig/kubeconfig.go
+++ b/internal/kubeconfig/kubeconfig.go
@@ -6,8 +6,12 @@ SPDX-License-Identifier: Apache-2.0
 package kubeconfig
 
 import (
-	"github.com/spf13/afero"
+	"path/filepath"
+	"sort"
+
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/vmware/octant/internal/util/strings"
 )
 
 //go:generate mockgen -destination=./fake/mock_loader.go -package=fake github.com/vmware/octant/internal/kubeconfig Loader
@@ -33,16 +37,13 @@ type FSLoaderOpt func(loader *FSLoader)
 
 // FSLoader loads kube configs from the file system.
 type FSLoader struct {
-	AppFS afero.Fs
 }
 
 var _ Loader = (*FSLoader)(nil)
 
 // NewFSLoader creates an instance of FSLoader.
 func NewFSLoader(options ...FSLoaderOpt) *FSLoader {
-	l := &FSLoader{
-		AppFS: afero.NewOsFs(),
-	}
+	l := &FSLoader{}
 
 	for _, option := range options {
 		option(l)
@@ -51,14 +52,15 @@ func NewFSLoader(options ...FSLoaderOpt) *FSLoader {
 	return l
 }
 
-// Load loads a kube config contexts from a file.
-func (l *FSLoader) Load(filename string) (*KubeConfig, error) {
-	data, err := afero.ReadFile(l.AppFS, filename)
-	if err != nil {
-		return nil, err
+// Load loads a kube config contexts from a list of files.
+func (l *FSLoader) Load(fileList string) (*KubeConfig, error) {
+	chain := strings.Deduplicate(filepath.SplitList(fileList))
+
+	loadingRules := &clientcmd.ClientConfigLoadingRules{
+		Precedence: chain,
 	}
 
-	config, err := clientcmd.Load(data)
+	config, err := loadingRules.Load()
 	if err != nil {
 		return nil, err
 	}
@@ -68,6 +70,10 @@ func (l *FSLoader) Load(filename string) (*KubeConfig, error) {
 	for name := range config.Contexts {
 		list = append(list, Context{Name: name})
 	}
+
+	sort.Slice(list, func(i, j int) bool {
+		return list[i].Name < list[j].Name
+	})
 
 	return &KubeConfig{
 		Contexts:       list,

--- a/internal/kubeconfig/kubeconfig_test.go
+++ b/internal/kubeconfig/kubeconfig_test.go
@@ -8,28 +8,35 @@ package kubeconfig
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestFSLoader_Load(t *testing.T) {
-	fs := afero.NewMemMapFs()
-
-	data, err := ioutil.ReadFile(filepath.Join("testdata", "kubeconfig.yaml"))
+	dir, err := ioutil.TempDir("", "loader-test")
 	require.NoError(t, err)
-	require.NoError(t, afero.WriteFile(fs, "/path", data, 0644))
+	defer func() {
+		require.NoError(t, os.RemoveAll(dir))
+	}()
 
-	opt := func(l *FSLoader) {
-		l.AppFS = fs
+	inputs := []string{"kubeconfig-1.yaml", "kubeconfig-2.yaml"}
+	var paths []string
+	for i := range inputs {
+		data, err := ioutil.ReadFile(filepath.Join("testdata", inputs[i]))
+		require.NoError(t, err)
+		kubeConfigPath := filepath.Join(dir, inputs[i])
+		require.NoError(t, ioutil.WriteFile(kubeConfigPath, data, 0644))
+		paths = append(paths, kubeConfigPath)
 	}
 
-	l := NewFSLoader(opt)
+	l := NewFSLoader()
 
-	kc, err := l.Load("/path")
+	kc, err := l.Load(strings.Join(paths, ":"))
 	require.NoError(t, err)
 
 	expected := &KubeConfig{

--- a/internal/kubeconfig/testdata/kubeconfig-1.yaml
+++ b/internal/kubeconfig/testdata/kubeconfig-1.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Config
+preferences: {}
+
+clusters:
+  - cluster:
+    name: development
+  - cluster:
+    name: scratch
+
+users:
+  - name: developer
+  - name: experimenter
+
+contexts:
+  - context:
+    name: dev-frontend
+  - context:
+    name: dev-storage
+current-context: dev-frontend

--- a/internal/kubeconfig/testdata/kubeconfig-2.yaml
+++ b/internal/kubeconfig/testdata/kubeconfig-2.yaml
@@ -14,9 +14,5 @@ users:
 
 contexts:
   - context:
-    name: dev-frontend
-  - context:
-    name: dev-storage
-  - context:
     name: exp-scratch
-current-context: dev-frontend
+current-context: exp-scratch

--- a/internal/modules/configuration/kube_context.go
+++ b/internal/modules/configuration/kube_context.go
@@ -9,16 +9,17 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"sort"
 	"time"
 
 	"github.com/pkg/errors"
 
 	"github.com/vmware/octant/internal/api"
-	"github.com/vmware/octant/internal/octant"
 	"github.com/vmware/octant/internal/config"
 	"github.com/vmware/octant/internal/event"
 	"github.com/vmware/octant/internal/kubeconfig"
 	"github.com/vmware/octant/internal/log"
+	"github.com/vmware/octant/internal/octant"
 )
 
 // kubeContextsResponse is a response for current kube contexts.
@@ -114,6 +115,10 @@ func (g *kubeContextGenerator) Event(ctx context.Context) (octant.Event, error) 
 		CurrentContext: currentContext,
 		Contexts:       kubeConfig.Contexts,
 	}
+
+	sort.Slice(resp.Contexts, func(i, j int) bool {
+		return resp.Contexts[i].Name < resp.Contexts[j].Name
+	})
 
 	data, err := json.Marshal(&resp)
 	if err != nil {

--- a/internal/util/strings/strings.go
+++ b/internal/util/strings/strings.go
@@ -15,3 +15,17 @@ func Contains(s string, sl []string) bool {
 
 	return false
 }
+
+// Deduplicate removes any duplicated values and returns a new slice, keeping the order unchanged
+func Deduplicate(s []string) []string {
+	encountered := map[string]bool{}
+	ret := make([]string, 0)
+	for i := range s {
+		if encountered[s[i]] {
+			continue
+		}
+		encountered[s[i]] = true
+		ret = append(ret, s[i])
+	}
+	return ret
+}

--- a/internal/util/strings/strings_test.go
+++ b/internal/util/strings/strings_test.go
@@ -32,10 +32,18 @@ func TestContains(t *testing.T) {
 		},
 	}
 
-	for _, tc := range cases {
+	for i := range cases {
+		tc := cases[i]
 		t.Run(tc.name, func(t *testing.T) {
 			got := Contains(tc.s, tc.sl)
 			assert.Equal(t, tc.expected, got)
 		})
 	}
+}
+
+func TestDeduplicate(t *testing.T) {
+	input := []string{"a", "a", "b", "c", "c"}
+	got := Deduplicate(input)
+	expected := []string{"a", "b", "c"}
+	assert.Equal(t, expected, got)
 }

--- a/web/src/app/modules/overview/components/context-selector/context-selector.component.html
+++ b/web/src/app/modules/overview/components/context-selector/context-selector.component.html
@@ -24,4 +24,8 @@
   </clr-dropdown>
 </ng-template>
 
-<ng-template #noContexts></ng-template>
+<ng-template #noContexts>
+  <a href="javascript://" class="nav-link nav-icon-text">
+    <span class="nav-text">No contexts!</span>
+  </a>
+</ng-template>


### PR DESCRIPTION
This change supports multiple configs in the same way kubectl does ie. `filea:fileb:filec`

#147