### PR TITLE
Handle initial namespace routing with resolver

### DIFF
--- a/changelogs/unreleased/165-GuessWhoSamFoo
+++ b/changelogs/unreleased/165-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Fixed intial set namespace flag by respecting initial URL routing.

--- a/internal/octant/event.go
+++ b/internal/octant/event.go
@@ -10,7 +10,7 @@ type EventType string
 const (
 	// EventTypeContent is a content event.
 	EventTypeContent EventType = "content"
-	// EventTypeNamespaces is a namespaces events.
+	// EventTypeNamespaces is a namespaces event.
 	EventTypeNamespaces EventType = "namespaces"
 	// EventTypeNavigation is a navigation event.
 	EventTypeNavigation EventType = "navigation"

--- a/web/src/app/app-routing.module.ts
+++ b/web/src/app/app-routing.module.ts
@@ -8,13 +8,16 @@ import { RouterModule, Routes } from '@angular/router';
 
 import { OverviewComponent } from './modules/overview/overview.component';
 import { PageNotFoundComponent } from './components/page-not-found/page-not-found.component';
+import { NamespaceResolver } from 'src/app/services/namespace/namespace-resolver.service';
 
 export const appRoutes: Routes = [
   { path: 'content', children: [{ path: '**', component: OverviewComponent }] },
-  // TODO: we shouldn't assume that the default namespace is valid
   {
     path: '',
-    redirectTo: '/content/overview/namespace/default/',
+    component: OverviewComponent,
+    resolve: {
+      namespace: NamespaceResolver
+    },
     pathMatch: 'full',
   },
   { path: '**', component: PageNotFoundComponent },
@@ -27,6 +30,9 @@ export const appRoutes: Routes = [
       useHash: true,
     }),
     CommonModule,
+  ],
+  providers: [
+    NamespaceResolver
   ],
 })
 export class AppRoutingModule {}

--- a/web/src/app/models/namespace.ts
+++ b/web/src/app/models/namespace.ts
@@ -5,3 +5,7 @@
 export interface Namespaces {
   namespaces: string[];
 }
+
+export interface Namespace {
+  namespace: string;
+}

--- a/web/src/app/services/namespace/namespace-resolver.service.ts
+++ b/web/src/app/services/namespace/namespace-resolver.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { Router, Resolve } from '@angular/router';
+import { Observable } from 'rxjs';
+import { NamespaceService } from 'src/app/services/namespace/namespace.service';
+import { Namespace } from 'src/app/models/namespace';
+
+@Injectable({
+   providedIn: 'root'
+})
+export class NamespaceResolver implements Resolve<Namespace> {
+  namespaces: string[];
+  initialNamespace: string;
+  url = '/content/overview/namespace/'
+
+  constructor(
+    private namespaceService: NamespaceService,
+    private router: Router,
+  ) {
+    this.namespaceService.getInitialNamespace().subscribe((initial: Namespace) => {
+      this.initialNamespace = initial.namespace;
+      this.router.navigate([this.url + this.initialNamespace]);
+    });
+  }
+
+  resolve(): Observable<any> {
+    this.router.navigate([this.url + this.namespaceService.current.getValue()]);
+    return;
+  }
+}

--- a/web/src/app/services/namespace/namespace.service.ts
+++ b/web/src/app/services/namespace/namespace.service.ts
@@ -3,6 +3,7 @@
 //
 
 import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
 import { NavigationEnd, PRIMARY_OUTLET, Router } from '@angular/router';
 import { BehaviorSubject } from 'rxjs';
 import _ from 'lodash';
@@ -18,6 +19,7 @@ import {
 } from '../notifier/notifier.service';
 import { includesArray } from '../../util/includesArray';
 import { Namespaces } from '../../models/namespace';
+import getAPIBase from '../common/getAPIBase';
 
 @Injectable({
   providedIn: 'root',
@@ -30,6 +32,7 @@ export class NamespaceService {
 
   constructor(
     private router: Router,
+    private http: HttpClient,
     private contentStreamService: ContentStreamService,
     notifierService: NotifierService
   ) {
@@ -74,6 +77,14 @@ export class NamespaceService {
     if (currentNS !== namespace) {
       this.current.next(namespace);
     }
+  }
+
+  public getInitialNamespace() {
+    const url = [
+        getAPIBase(),
+        'api/v1/namespace'
+    ].join('/');
+    return this.http.get(url)
   }
 
   private isNamespaceValid(namespaceToCheck: string): boolean {


### PR DESCRIPTION
This PR uses a resolver to check for the initial namespace from the endpoint `/api/v1/namespace`. It will still attempt redirecting to `/content/overview/namespace/default` until the initial namespace is returned.

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>