### PR TITLE
119 add loading indicators

### DIFF
--- a/changelogs/unreleased/176-bryanl
+++ b/changelogs/unreleased/176-bryanl
@@ -1,0 +1,1 @@
+add loading indicators to objects in nav when their informer has not synced

--- a/internal/api/navigation_test.go
+++ b/internal/api/navigation_test.go
@@ -44,7 +44,7 @@ func Test_navigation_handler(t *testing.T) {
 			name:       "in general",
 			nav:        newNavigationHandler(validSections, logger),
 			statusCode: http.StatusOK,
-			body:       []byte("{\"sections\":[{}]}\n"),
+			body:       []byte("{\"sections\":[{\"isLoading\":false}]}\n"),
 		},
 		{
 			name:       "no section generator",

--- a/internal/describer/crd_list.go
+++ b/internal/describer/crd_list.go
@@ -26,7 +26,8 @@ type crdListPrinter func(
 	crdName string,
 	crd *apiextv1beta1.CustomResourceDefinition,
 	objects *unstructured.UnstructuredList,
-	linkGenerator link.Interface) (component.Component, error)
+	linkGenerator link.Interface,
+	isLoading bool) (component.Component, error)
 
 type crdListDescriptionOption func(*crdList)
 
@@ -61,12 +62,12 @@ func (cld *crdList) Describe(ctx context.Context, prefix, namespace string, opti
 		return EmptyContentResponse, err
 	}
 
-	objects, err := ListCustomResources(ctx, crd, namespace, objectStore, options.LabelSet)
+	objects, isLoading, err := ListCustomResources(ctx, crd, namespace, objectStore, options.LabelSet)
 	if err != nil {
 		return EmptyContentResponse, err
 	}
 
-	table, err := cld.printer(cld.name, crd, objects, options.Link)
+	table, err := cld.printer(cld.name, crd, objects, options.Link, isLoading)
 	if err != nil {
 		return EmptyContentResponse, err
 	}
@@ -88,9 +89,9 @@ func ListCustomResources(
 	crd *apiextv1beta1.CustomResourceDefinition,
 	namespace string,
 	o store.Store,
-	selector *labels.Set) (*unstructured.UnstructuredList, error) {
+	selector *labels.Set) (*unstructured.UnstructuredList, bool, error) {
 	if crd == nil {
-		return nil, errors.New("crd is nil")
+		return nil, false, errors.New("crd is nil")
 	}
 	gvk := schema.GroupVersionKind{
 		Group:   crd.Spec.Group,
@@ -107,16 +108,12 @@ func ListCustomResources(
 		Selector:   selector,
 	}
 
-	if err := o.HasAccess(ctx, key, "list"); err != nil {
-		return nil, nil
-	}
-
-	objects, err := o.List(ctx, key)
+	objects, isLoading, err := o.List(ctx, key)
 	if err != nil {
-		return nil, errors.Wrapf(err, "listing custom resources for %q", crd.Name)
+		return nil, false, errors.Wrapf(err, "listing custom resources for %q", crd.Name)
 	}
 
-	return objects, nil
+	return objects, isLoading, nil
 }
 
 func (cld *crdList) PathFilters() []PathFilter {

--- a/internal/describer/crd_list_test.go
+++ b/internal/describer/crd_list_test.go
@@ -40,7 +40,6 @@ func Test_crdListDescriber(t *testing.T) {
 		Name:       crd.Name,
 	}
 
-	o.EXPECT().HasAccess(gomock.Any(), gomock.Any(), "list").Return(nil)
 	o.EXPECT().Get(gomock.Any(), gomock.Eq(crdKey)).Return(testutil.ToUnstructured(t, crd), nil)
 
 	crKey := store.Key{
@@ -50,10 +49,10 @@ func Test_crdListDescriber(t *testing.T) {
 	}
 
 	objects := &unstructured.UnstructuredList{}
-	o.EXPECT().List(gomock.Any(), gomock.Eq(crKey)).Return(objects, nil)
+	o.EXPECT().List(gomock.Any(), gomock.Eq(crKey)).Return(objects, false, nil)
 
 	listPrinter := func(cld *crdList) {
-		cld.printer = func(name string, crd *apiextv1beta1.CustomResourceDefinition, objects *unstructured.UnstructuredList, linkGenerator link.Interface) (component.Component, error) {
+		cld.printer = func(name string, crd *apiextv1beta1.CustomResourceDefinition, objects *unstructured.UnstructuredList, linkGenerator link.Interface, loading bool) (component.Component, error) {
 			return component.NewText("crd list"), nil
 		}
 	}

--- a/internal/describer/customresource.go
+++ b/internal/describer/customresource.go
@@ -18,6 +18,7 @@ import (
 	"github.com/vmware/octant/pkg/store"
 )
 
+// TODO: delete me
 func CustomResourceDefinitionNames(ctx context.Context, o store.Store) ([]string, error) {
 	key := store.Key{
 		APIVersion: "apiextensions.k8s.io/v1beta1",
@@ -28,7 +29,7 @@ func CustomResourceDefinitionNames(ctx context.Context, o store.Store) ([]string
 		return []string{}, nil
 	}
 
-	rawList, err := o.List(ctx, key)
+	rawList, _, err := o.List(ctx, key)
 	if err != nil {
 		return nil, errors.Wrap(err, "listing CRDs")
 	}

--- a/internal/describer/customresource_test.go
+++ b/internal/describer/customresource_test.go
@@ -34,7 +34,7 @@ func Test_customResourceDefinitionNames(t *testing.T) {
 		Kind:       "CustomResourceDefinition",
 	}
 	o.EXPECT().HasAccess(gomock.Any(), gomock.Any(), "list").Return(nil)
-	o.EXPECT().List(gomock.Any(), gomock.Eq(crdKey)).Return(crdList, nil)
+	o.EXPECT().List(gomock.Any(), gomock.Eq(crdKey)).Return(crdList, false, nil)
 
 	ctx := context.Background()
 	got, err := CustomResourceDefinitionNames(ctx, o)

--- a/internal/describer/describer.go
+++ b/internal/describer/describer.go
@@ -72,7 +72,7 @@ func LoadObjects(ctx context.Context, objectStore store.Store, namespace string,
 			objectStoreKey.Name = name
 		}
 
-		storedObjects, err := objectStore.List(ctx, objectStoreKey)
+		storedObjects, _, err := objectStore.List(ctx, objectStoreKey)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/describer/describer_test.go
+++ b/internal/describer/describer_test.go
@@ -47,7 +47,7 @@ func (c emptyComponent) MarshalJSON() ([]byte, error) {
 
 func createPodTable(pods ...corev1.Pod) *component.Table {
 	tableCols := component.NewTableCols("Name", "Labels", "Age")
-	table := component.NewTable("/v1, Kind=PodList", tableCols)
+	table := component.NewTable("/v1, Kind=PodList", "placeholder", tableCols)
 	for _, pod := range pods {
 		table.Add(component.TableRow{
 			"Age":    component.NewTimestamp(pod.CreationTimestamp.Time),

--- a/internal/describer/section.go
+++ b/internal/describer/section.go
@@ -35,16 +35,16 @@ func NewSection(p, title string, describers ...Describer) *Section {
 func (d *Section) Describe(ctx context.Context, prefix, namespace string, options Options) (component.ContentResponse, error) {
 	list := component.NewList(d.title, nil)
 
-	for _, child := range d.describers {
-		cResponse, err := child.Describe(ctx, prefix, namespace, options)
+	for describerIndex := range d.describers {
+		cResponse, err := d.describers[describerIndex].Describe(ctx, prefix, namespace, options)
 		if err != nil {
 			return EmptyContentResponse, err
 		}
 
-		for _, vc := range cResponse.Components {
-			if nestedList, ok := vc.(*component.List); ok {
-				for i := range nestedList.Config.Items {
-					item := nestedList.Config.Items[i]
+		for componentIndex := range cResponse.Components {
+			if nestedList, ok := cResponse.Components[componentIndex].(*component.List); ok {
+				for itemIndex := range nestedList.Config.Items {
+					item := nestedList.Config.Items[itemIndex]
 					if !item.IsEmpty() {
 						list.Add(item)
 					}

--- a/internal/loading/loading.go
+++ b/internal/loading/loading.go
@@ -1,0 +1,23 @@
+package loading
+
+import (
+	"context"
+
+	"github.com/vmware/octant/internal/describer"
+	"github.com/vmware/octant/internal/log"
+	"github.com/vmware/octant/pkg/store"
+)
+
+func IsObjectLoading(ctx context.Context, namespace string, resource *describer.Resource, objectStore store.Store) bool {
+	logger := log.From(ctx)
+
+	if resource == nil {
+		logger.Debugf("can't determine if a nil object is loading")
+		return false
+	}
+
+	key := resource.ObjectStoreKey
+	key.Namespace = namespace
+
+	return objectStore.IsLoading(ctx, key)
+}

--- a/internal/modules/clusteroverview/port_forward_describer.go
+++ b/internal/modules/clusteroverview/port_forward_describer.go
@@ -30,7 +30,7 @@ func (d *PortForwardListDescriber) Describe(ctx context.Context, prefix, namespa
 	list := component.NewList("Port Forwards", nil)
 
 	tblCols := component.NewTableCols("Name", "Namespace", "Ports", "Age")
-	tbl := component.NewTable("Port Forwards", tblCols)
+	tbl := component.NewTable("Port Forwards", "There are no port forwards!", tblCols)
 	list.Add(tbl)
 
 	for _, pf := range portForwarder.List() {

--- a/internal/modules/configuration/plugin_describer.go
+++ b/internal/modules/configuration/plugin_describer.go
@@ -27,7 +27,7 @@ func (d *PluginListDescriber) Describe(ctx context.Context, prefix, namespace st
 
 	list := component.NewList("Plugins", nil)
 	tableCols := component.NewTableCols("Name", "Description", "Capabilities")
-	tbl := component.NewTable("Plugins", tableCols)
+	tbl := component.NewTable("Plugins", "There are no plugins!", tableCols)
 	list.Add(tbl)
 
 	for _, n := range pluginStore.ClientNames() {

--- a/internal/modules/configuration/plugin_describer_test.go
+++ b/internal/modules/configuration/plugin_describer_test.go
@@ -60,7 +60,7 @@ func TestPluginDescriber(t *testing.T) {
 
 	list := component.NewList("Plugins", nil)
 	tableCols := component.NewTableCols("Name", "Description", "Capabilities")
-	table := component.NewTable("Plugins", tableCols)
+	table := component.NewTable("Plugins", "There are no plugins!", tableCols)
 	table.Add(component.TableRow{
 		"Name":        component.NewText(name),
 		"Description": component.NewText("this is a test"),

--- a/internal/modules/localcontent/localcontent.go
+++ b/internal/modules/localcontent/localcontent.go
@@ -59,7 +59,7 @@ func (l *LocalContent) list() (component.ContentResponse, error) {
 	var out component.ContentResponse
 
 	cols := component.NewTableCols("Title", "File")
-	table := component.NewTable("Local Components", cols)
+	table := component.NewTable("Local Components", "We couldn't find any local content!", cols)
 
 	err := l.walk(func(name, base string, content component.ContentResponse) error {
 		title, err := l.titleToText(content.Title)

--- a/internal/modules/overview/content_handlers_test.go
+++ b/internal/modules/overview/content_handlers_test.go
@@ -60,7 +60,7 @@ func Test_loadObjects(t *testing.T) {
 
 				o.EXPECT().
 					List(gomock.Any(), gomock.Eq(key)).
-					Return(sampleObjects, nil)
+					Return(sampleObjects, false, nil)
 			},
 			fields:   map[string]string{},
 			keys:     []store.Key{{APIVersion: "v1", Kind: "kind"}},
@@ -77,7 +77,7 @@ func Test_loadObjects(t *testing.T) {
 
 				o.EXPECT().
 					List(gomock.Any(), gomock.Eq(key)).
-					Return(&unstructured.UnstructuredList{}, nil)
+					Return(&unstructured.UnstructuredList{}, false, nil)
 
 			},
 			fields:   map[string]string{"name": "name"},
@@ -94,7 +94,7 @@ func Test_loadObjects(t *testing.T) {
 
 				o.EXPECT().
 					List(gomock.Any(), gomock.Eq(key)).
-					Return(nil, errors.New("error"))
+					Return(nil, false, errors.New("error"))
 			},
 			fields: map[string]string{},
 			keys:   []store.Key{{APIVersion: "v1", Kind: "kind"}},

--- a/internal/modules/overview/navigation.go
+++ b/internal/modules/overview/navigation.go
@@ -8,6 +8,7 @@ package overview
 import (
 	"context"
 
+	"github.com/vmware/octant/internal/loading"
 	"github.com/vmware/octant/pkg/icon"
 	"github.com/vmware/octant/pkg/navigation"
 	"github.com/vmware/octant/pkg/store"
@@ -24,43 +25,80 @@ var (
 	}
 )
 
-func workloadEntries(_ context.Context, prefix, _ string, _ store.Store, _ bool) ([]navigation.Navigation, error) {
+func workloadEntries(ctx context.Context, prefix, namespace string, objectStore store.Store, _ bool) ([]navigation.Navigation, bool, error) {
 	neh := navigation.EntriesHelper{}
-	neh.Add("Cron Jobs", "cron-jobs", icon.OverviewCronJob)
-	neh.Add("Daemon Sets", "daemon-sets", icon.OverviewDaemonSet)
-	neh.Add("Deployments", "deployments", icon.OverviewDeployment)
-	neh.Add("Jobs", "jobs", icon.OverviewJob)
-	neh.Add("Pods", "pods", icon.OverviewPod)
-	neh.Add("Replica Sets", "replica-sets", icon.OverviewReplicaSet)
-	neh.Add("Replication Controllers", "replication-controllers", icon.OverviewReplicationController)
-	neh.Add("Stateful Sets", "stateful-sets", icon.OverviewStatefulSet)
 
-	return neh.Generate(prefix)
+	neh.Add("Cron Jobs", "cron-jobs", icon.OverviewCronJob,
+		loading.IsObjectLoading(ctx, namespace, workloadsCronJobs, objectStore))
+	neh.Add("Daemon Sets", "daemon-sets", icon.OverviewDaemonSet,
+		loading.IsObjectLoading(ctx, namespace, workloadsDaemonSets, objectStore))
+	neh.Add("Deployments", "deployments", icon.OverviewDeployment,
+		loading.IsObjectLoading(ctx, namespace, workloadsDeployments, objectStore))
+	neh.Add("Jobs", "jobs", icon.OverviewJob,
+		loading.IsObjectLoading(ctx, namespace, workloadsJobs, objectStore))
+	neh.Add("Pods", "pods", icon.OverviewPod,
+		loading.IsObjectLoading(ctx, namespace, workloadsPods, objectStore))
+	neh.Add("Replica Sets", "replica-sets", icon.OverviewReplicaSet,
+		loading.IsObjectLoading(ctx, namespace, workloadsReplicaSets, objectStore))
+	neh.Add("Replication Controllers", "replication-controllers", icon.OverviewReplicationController,
+		loading.IsObjectLoading(ctx, namespace, workloadsReplicationControllers, objectStore))
+	neh.Add("Stateful Sets", "stateful-sets", icon.OverviewStatefulSet,
+		loading.IsObjectLoading(ctx, namespace, workloadsStatefulSets, objectStore))
+
+	children, err := neh.Generate(prefix)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return children, false, nil
 }
 
-func discoAndLBEntries(_ context.Context, prefix, _ string, _ store.Store, _ bool) ([]navigation.Navigation, error) {
+func discoAndLBEntries(ctx context.Context, prefix, namespace string, objectStore store.Store, _ bool) ([]navigation.Navigation, bool, error) {
 	neh := navigation.EntriesHelper{}
-	neh.Add("Ingresses", "ingresses", icon.OverviewIngress)
-	neh.Add("Services", "services", icon.OverviewService)
+	neh.Add("Ingresses", "ingresses", icon.OverviewIngress,
+		loading.IsObjectLoading(ctx, namespace, dlbIngresses, objectStore))
+	neh.Add("Services", "services", icon.OverviewService,
+		loading.IsObjectLoading(ctx, namespace, dlbServices, objectStore))
 
-	return neh.Generate(prefix)
+	children, err := neh.Generate(prefix)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return children, false, nil
 }
 
-func configAndStorageEntries(_ context.Context, prefix, _ string, _ store.Store, _ bool) ([]navigation.Navigation, error) {
+func configAndStorageEntries(ctx context.Context, prefix, namespace string, objectStore store.Store, _ bool) ([]navigation.Navigation, bool, error) {
 	neh := navigation.EntriesHelper{}
-	neh.Add("Config Maps", "config-maps", icon.OverviewConfigMap)
-	neh.Add("Persistent Volume Claims", "persistent-volume-claims", icon.OverviewPersistentVolumeClaim)
-	neh.Add("Secrets", "secrets", icon.OverviewSecret)
-	neh.Add("Service Accounts", "service-accounts", icon.OverviewServiceAccount)
+	neh.Add("Config Maps", "config-maps", icon.OverviewConfigMap,
+		loading.IsObjectLoading(ctx, namespace, csConfigMaps, objectStore))
+	neh.Add("Persistent Volume Claims", "persistent-volume-claims", icon.OverviewPersistentVolumeClaim,
+		loading.IsObjectLoading(ctx, namespace, csPVCs, objectStore))
+	neh.Add("Secrets", "secrets", icon.OverviewSecret,
+		loading.IsObjectLoading(ctx, namespace, csSecrets, objectStore))
+	neh.Add("Service Accounts", "service-accounts", icon.OverviewServiceAccount,
+		loading.IsObjectLoading(ctx, namespace, csServiceAccounts, objectStore))
 
-	return neh.Generate(prefix)
+	children, err := neh.Generate(prefix)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return children, false, nil
 }
 
-func rbacEntries(_ context.Context, prefix, _ string, _ store.Store, _ bool) ([]navigation.Navigation, error) {
+func rbacEntries(ctx context.Context, prefix, namespace string, objectStore store.Store, _ bool) ([]navigation.Navigation, bool, error) {
 	neh := navigation.EntriesHelper{}
 
-	neh.Add("Roles", "roles", icon.OverviewRole)
-	neh.Add("Role Bindings", "role-bindings", icon.OverviewRoleBinding)
+	neh.Add("Roles", "roles", icon.OverviewRole,
+		loading.IsObjectLoading(ctx, namespace, rbacRoles, objectStore))
+	neh.Add("Role Bindings", "role-bindings", icon.OverviewRoleBinding,
+		loading.IsObjectLoading(ctx, namespace, rbacRoleBindings, objectStore))
 
-	return neh.Generate(prefix)
+	children, err := neh.Generate(prefix)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return children, false, nil
 }

--- a/internal/modules/overview/printer/affinity.go
+++ b/internal/modules/overview/printer/affinity.go
@@ -26,7 +26,8 @@ type affinityDescriber struct {
 func (ad *affinityDescriber) Create() (*component.Table, error) {
 
 	cols := component.NewTableCols("Type", "Description")
-	table := component.NewTable("Affinities and Anti-Affinities", cols)
+	table := component.NewTable("Affinities and Anti-Affinities",
+		"There are no affinities or anti-affinities!", cols)
 
 	if affinity := ad.podSpec.Affinity; affinity != nil {
 		for _, nodeAffinity := range ad.nodeAffinity(*affinity) {

--- a/internal/modules/overview/printer/affinity_test.go
+++ b/internal/modules/overview/printer/affinity_test.go
@@ -8,7 +8,6 @@ package printer
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,6 +18,7 @@ import (
 func affinityTable(affinityType, description string) *component.Table {
 	return component.NewTableWithRows(
 		"Affinities and Anti-Affinities",
+		"There are no affinities or anti-affinities!",
 		component.NewTableCols("Type", "Description"),
 		[]component.TableRow{
 			{
@@ -384,7 +384,7 @@ func Test_affinityDescriber_Create(t *testing.T) {
 
 			require.NoError(t, err)
 
-			assert.Equal(t, tc.expected, got)
+			component.AssertEqual(t, tc.expected, got)
 		})
 	}
 }

--- a/internal/modules/overview/printer/clusterrole.go
+++ b/internal/modules/overview/printer/clusterrole.go
@@ -23,7 +23,7 @@ func ClusterRoleListHandler(_ context.Context, list *rbacv1.ClusterRoleList, opt
 	}
 
 	cols := component.NewTableCols("Name", "Age")
-	tbl := component.NewTable("Cluster Roles", cols)
+	tbl := component.NewTable("Cluster Roles", "We couldn't find any cluster roles!", cols)
 
 	for _, clusterRole := range list.Items {
 		row := component.TableRow{}
@@ -118,7 +118,7 @@ func printPolicyRules(rules []rbacv1.PolicyRule) (*component.Table, error) {
 	})
 
 	cols := component.NewTableCols("Resources", "Non-Resource URLs", "Resource Names", "Verbs")
-	tbl := component.NewTable("Policy Rules", cols)
+	tbl := component.NewTable("Policy Rules", "There are no policy rules!", cols)
 
 	for _, r := range rules {
 		row := component.TableRow{}

--- a/internal/modules/overview/printer/clusterrole_test.go
+++ b/internal/modules/overview/printer/clusterrole_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,7 +41,7 @@ func Test_ClusterRoleListHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	cols := component.NewTableCols("Name", "Age")
-	expected := component.NewTable("Cluster Roles", cols)
+	expected := component.NewTable("Cluster Roles", "We couldn't find any cluster roles!", cols)
 	expected.Add(component.TableRow{
 		"Name": component.NewLink("", object.Name, "/path"),
 		"Age":  component.NewTimestamp(now),
@@ -77,7 +76,7 @@ func Test_printClusterRolePolicyRule(t *testing.T) {
 	require.NoError(t, err)
 
 	cols := component.NewTableCols("Resources", "Non-Resource URLs", "Resource Names", "Verbs")
-	expected := component.NewTable("Policy Rules", cols)
+	expected := component.NewTable("Policy Rules", "There are no policy rules!", cols)
 
 	row := component.TableRow{}
 	row["Resources"] = component.NewText("crontabs.stable.example.com")
@@ -87,5 +86,5 @@ func Test_printClusterRolePolicyRule(t *testing.T) {
 
 	expected.Add(row)
 
-	assert.Equal(t, expected, observed)
+	component.AssertEqual(t, expected, observed)
 }

--- a/internal/modules/overview/printer/clusterrolebinding.go
+++ b/internal/modules/overview/printer/clusterrolebinding.go
@@ -21,7 +21,7 @@ func ClusterRoleBindingListHandler(_ context.Context, clusterRoleBindingList *rb
 	}
 
 	columns := component.NewTableCols("Name", "Labels", "Age", "Role kind", "Role name")
-	table := component.NewTable("Cluster Role Bindings", columns)
+	table := component.NewTable("Cluster Role Bindings", "We couldn't find any cluster role bindings!", columns)
 
 	for _, roleBinding := range clusterRoleBindingList.Items {
 		row := component.TableRow{}
@@ -108,7 +108,7 @@ func printClusterRoleBindingSubjects(roleBinding *rbacv1.ClusterRoleBinding) (co
 	}
 
 	columns := component.NewTableCols("Kind", "Name", "Namespace")
-	table := component.NewTable("Subjects", columns)
+	table := component.NewTable("Subjects", "There are no subjects!", columns)
 
 	for _, subject := range roleBinding.Subjects {
 		row := component.TableRow{}

--- a/internal/modules/overview/printer/clusterrolebinding_test.go
+++ b/internal/modules/overview/printer/clusterrolebinding_test.go
@@ -51,7 +51,7 @@ func Test_ClusterRoleBindingListHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	cols := component.NewTableCols("Name", "Labels", "Age", "Role kind", "Role name")
-	expected := component.NewTable("Cluster Role Bindings", cols)
+	expected := component.NewTable("Cluster Role Bindings", "We couldn't find any cluster role bindings!", cols)
 	expected.Add(component.TableRow{
 		"Name":      component.NewLink("", clusterRoleBinding.Name, "/cluster-role-binding-path"),
 		"Labels":    component.NewLabels(labels),
@@ -81,7 +81,7 @@ func Test_printClusterRoleBindingSubjects(t *testing.T) {
 	require.NoError(t, err)
 
 	columns := component.NewTableCols("Kind", "Name", "Namespace")
-	expected := component.NewTable("Subjects", columns)
+	expected := component.NewTable("Subjects", "There are no subjects!", columns)
 
 	row := component.TableRow{}
 	row["Kind"] = component.NewText("User")

--- a/internal/modules/overview/printer/configmap.go
+++ b/internal/modules/overview/printer/configmap.go
@@ -25,7 +25,7 @@ func ConfigMapListHandler(_ context.Context, list *corev1.ConfigMapList, opts Op
 
 	// Data column
 	cols := component.NewTableCols("Name", "Labels", "Data", "Age")
-	tbl := component.NewTable("ConfigMaps", cols)
+	tbl := component.NewTable("ConfigMaps", "We couldn't find any config maps!", cols)
 
 	for _, c := range list.Items {
 		row := component.TableRow{}
@@ -109,7 +109,7 @@ func describeConfigMapData(cm *corev1.ConfigMap) (*component.Table, error) {
 	}
 
 	cols := component.NewTableCols("Key", "Value")
-	tbl := component.NewTable("Data", cols)
+	tbl := component.NewTable("Data", "No data has been configured for this config map!", cols)
 
 	rows, err := describeConfigMapDataRows(cm)
 	if err != nil {

--- a/internal/modules/overview/printer/configmap_test.go
+++ b/internal/modules/overview/printer/configmap_test.go
@@ -51,7 +51,7 @@ func Test_ConfigMapListHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	cols := component.NewTableCols("Name", "Labels", "Data", "Age")
-	expected := component.NewTable("ConfigMaps", cols)
+	expected := component.NewTable("ConfigMaps", "We couldn't find any config maps!", cols)
 	expected.Add(component.TableRow{
 		"Name":   component.NewLink("", configMap.Name, "/configMap"),
 		"Labels": component.NewLabels(labels),
@@ -81,13 +81,13 @@ func Test_describeConfigMapConfiguration(t *testing.T) {
 
 	cases := []struct {
 		name      string
-		configmap *corev1.ConfigMap
+		configMap *corev1.ConfigMap
 		isErr     bool
 		expected  *component.Summary
 	}{
 		{
 			name:      "configmap",
-			configmap: validConfigMap,
+			configMap: validConfigMap,
 			expected: component.NewSummary("Configuration", []component.SummarySection{
 				{
 					Header:  "Age",
@@ -97,14 +97,14 @@ func Test_describeConfigMapConfiguration(t *testing.T) {
 		},
 		{
 			name:      "configmap is nil",
-			configmap: nil,
+			configMap: nil,
 			isErr:     true,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			summary, err := describeConfigMapConfig(tc.configmap)
+			summary, err := describeConfigMapConfig(tc.configMap)
 			if tc.isErr {
 				require.Error(t, err)
 				return

--- a/internal/modules/overview/printer/container.go
+++ b/internal/modules/overview/printer/container.go
@@ -264,7 +264,7 @@ func describeContainerEnv(parent runtime.Object, c *corev1.Container, options Op
 	}
 
 	cols := component.NewTableCols("Name", "Value", "Source")
-	tbl := component.NewTable("Environment", cols)
+	tbl := component.NewTable("Environment", "There are no defined environment variables!", cols)
 
 	envRows, err := describeEnvRows(ns, c.Env, options)
 	if err != nil {
@@ -379,7 +379,7 @@ func printVolumeMountPath(mnt corev1.VolumeMount) string {
 
 func describeVolumeMounts(c *corev1.Container) *component.Table {
 	cols := component.NewTableCols("Name", "Mount Path", "Propagation")
-	tbl := component.NewTable("Volume Mounts", cols)
+	tbl := component.NewTable("Volume Mounts", "There are no volume mounts!", cols)
 
 	for _, m := range c.VolumeMounts {
 		row := component.TableRow{}

--- a/internal/modules/overview/printer/container_test.go
+++ b/internal/modules/overview/printer/container_test.go
@@ -132,7 +132,7 @@ func Test_ContainerConfiguration(t *testing.T) {
 
 	now := time.Now()
 
-	envTable := component.NewTable("Environment",
+	envTable := component.NewTable("Environment", "There are no defined environment variables!",
 		component.NewTableCols("Name", "Value", "Source"))
 	envTable.Add(
 		component.TableRow{
@@ -169,7 +169,7 @@ func Test_ContainerConfiguration(t *testing.T) {
 		},
 	)
 
-	volTable := component.NewTable("Volume Mounts",
+	volTable := component.NewTable("Volume Mounts", "There are no volume mounts!",
 		component.NewTableCols("Name", "Mount Path", "Propagation"))
 	volTable.Add(
 		component.TableRow{

--- a/internal/modules/overview/printer/cronjob.go
+++ b/internal/modules/overview/printer/cronjob.go
@@ -24,7 +24,7 @@ func CronJobListHandler(ctx context.Context, list *batchv1beta1.CronJobList, opt
 	}
 
 	cols := component.NewTableCols("Name", "Labels", "Schedule", "Age")
-	tbl := component.NewTable("CronJobs", cols)
+	tbl := component.NewTable("CronJobs", "We couldn't find any cron jobs!", cols)
 
 	for _, c := range list.Items {
 		row := component.TableRow{}

--- a/internal/modules/overview/printer/cronjob_test.go
+++ b/internal/modules/overview/printer/cronjob_test.go
@@ -65,7 +65,7 @@ func Test_CronJobListHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	cols := component.NewTableCols("Name", "Labels", "Schedule", "Age")
-	expected := component.NewTable("CronJobs", cols)
+	expected := component.NewTable("CronJobs", "We couldn't find any cron jobs!", cols)
 	expected.Add(component.TableRow{
 		"Name":     component.NewLink("", "cron", "/cron"),
 		"Labels":   component.NewLabels(labels),

--- a/internal/modules/overview/printer/customresource.go
+++ b/internal/modules/overview/printer/customresource.go
@@ -39,7 +39,7 @@ func CustomResourceListHandler(
 
 func printGenericCRDTable(crdName string, list *unstructured.UnstructuredList, linkGenerator link.Interface) (component.Component, error) {
 	cols := component.NewTableCols("Name", "Labels", "Age")
-	table := component.NewTable(crdName, cols)
+	table := component.NewTable(crdName, "We couldn't find any custom resources!", cols)
 
 	for i := range list.Items {
 		cr := list.Items[i]
@@ -68,7 +68,7 @@ func printCustomCRDListTable(
 	list *unstructured.UnstructuredList,
 	linkGenerator link.Interface) (component.Component, error) {
 
-	table := component.NewTable(crdName, component.NewTableCols("Name", "Labels"))
+	table := component.NewTable(crdName, "We couldn't find any custom resources!", component.NewTableCols("Name", "Labels"))
 	for _, column := range crd.Spec.AdditionalPrinterColumns {
 		name := column.Name
 		if dashstrings.Contains(column.Name, []string{"Name", "Labels", "Age"}) {

--- a/internal/modules/overview/printer/customresource.go
+++ b/internal/modules/overview/printer/customresource.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/client-go/util/jsonpath"
 
 	"github.com/vmware/octant/internal/link"
-	dashstrings "github.com/vmware/octant/internal/util/strings"
+	octantStrings "github.com/vmware/octant/internal/util/strings"
 	"github.com/vmware/octant/pkg/view/component"
 )
 
@@ -27,17 +27,18 @@ func CustomResourceListHandler(
 	crdName string,
 	crd *apiextv1beta1.CustomResourceDefinition,
 	list *unstructured.UnstructuredList,
-	linkGenerator link.Interface) (component.Component, error) {
+	linkGenerator link.Interface,
+	isLoading bool) (component.Component, error) {
 
 	hasCustomColumns := len(crd.Spec.AdditionalPrinterColumns) > 0
 	if hasCustomColumns {
-		return printCustomCRDListTable(crdName, crd, list, linkGenerator)
+		return printCustomCRDListTable(crdName, crd, list, linkGenerator, isLoading)
 	}
 
-	return printGenericCRDTable(crdName, list, linkGenerator)
+	return printGenericCRDTable(crdName, list, linkGenerator, isLoading)
 }
 
-func printGenericCRDTable(crdName string, list *unstructured.UnstructuredList, linkGenerator link.Interface) (component.Component, error) {
+func printGenericCRDTable(crdName string, list *unstructured.UnstructuredList, linkGenerator link.Interface, isLoading bool) (component.Component, error) {
 	cols := component.NewTableCols("Name", "Labels", "Age")
 	table := component.NewTable(crdName, "We couldn't find any custom resources!", cols)
 
@@ -57,6 +58,7 @@ func printGenericCRDTable(crdName string, list *unstructured.UnstructuredList, l
 		table.Add(row)
 	}
 
+	table.SetIsLoading(isLoading)
 	table.Sort("Name", false)
 
 	return table, nil
@@ -66,12 +68,13 @@ func printCustomCRDListTable(
 	crdName string,
 	crd *apiextv1beta1.CustomResourceDefinition,
 	list *unstructured.UnstructuredList,
-	linkGenerator link.Interface) (component.Component, error) {
+	linkGenerator link.Interface,
+	isLoading bool) (component.Component, error) {
 
 	table := component.NewTable(crdName, "We couldn't find any custom resources!", component.NewTableCols("Name", "Labels"))
 	for _, column := range crd.Spec.AdditionalPrinterColumns {
 		name := column.Name
-		if dashstrings.Contains(column.Name, []string{"Name", "Labels", "Age"}) {
+		if octantStrings.Contains(column.Name, []string{"Name", "Labels", "Age"}) {
 			name = fmt.Sprintf("Resource %s", column.Name)
 		}
 		table.AddColumn(name)
@@ -112,6 +115,7 @@ func printCustomCRDListTable(
 		table.Add(row)
 	}
 
+	table.SetIsLoading(isLoading)
 	table.Sort("Name", false)
 
 	return table, nil
@@ -180,7 +184,7 @@ func printCustomResourceConfig(u *unstructured.Unstructured, crd *apiextv1beta1.
 		return summary, nil
 	}
 
-	var sections component.SummarySections
+	sections := component.SummarySections{}
 
 	for _, column := range crd.Spec.AdditionalPrinterColumns {
 		if strings.HasPrefix(column.JSONPath, ".spec") {
@@ -212,7 +216,7 @@ func printCustomResourceStatus(u *unstructured.Unstructured, crd *apiextv1beta1.
 		return summary, nil
 	}
 
-	var sections component.SummarySections
+	sections := component.SummarySections{}
 
 	for _, column := range crd.Spec.AdditionalPrinterColumns {
 		if strings.HasPrefix(column.JSONPath, ".status") {

--- a/internal/modules/overview/printer/customresource_test.go
+++ b/internal/modules/overview/printer/customresource_test.go
@@ -45,7 +45,7 @@ func Test_CustomResourceListHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := component.NewTableWithRows(
-		"crontabs.stable.example.com",
+		"crontabs.stable.example.com", "We couldn't find any custom resources!",
 		component.NewTableCols("Name", "Labels", "Age"),
 		[]component.TableRow{
 			{
@@ -81,7 +81,7 @@ func Test_CustomResourceListHandler_custom_columns(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := component.NewTableWithRows(
-		"crontabs.stable.example.com",
+		"crontabs.stable.example.com", "We couldn't find any custom resources!",
 		component.NewTableCols("Name", "Labels", "Spec", "Replicas", "Errors", "Resource Age", "Age"),
 		[]component.TableRow{
 			{

--- a/internal/modules/overview/printer/customresource_test.go
+++ b/internal/modules/overview/printer/customresource_test.go
@@ -41,7 +41,7 @@ func Test_CustomResourceListHandler(t *testing.T) {
 	resource.SetLabels(labels)
 
 	list := testutil.ToUnstructuredList(t, resource)
-	got, err := CustomResourceListHandler(crd.Name, crd, list, tpo.link)
+	got, err := CustomResourceListHandler(crd.Name, crd, list, tpo.link, true)
 	require.NoError(t, err)
 
 	expected := component.NewTableWithRows(
@@ -54,6 +54,7 @@ func Test_CustomResourceListHandler(t *testing.T) {
 				"Labels": component.NewLabels(labels),
 			},
 		})
+	expected.SetIsLoading(true)
 
 	component.AssertEqual(t, expected, got)
 }
@@ -77,7 +78,7 @@ func Test_CustomResourceListHandler_custom_columns(t *testing.T) {
 
 	list := testutil.ToUnstructuredList(t, resource)
 
-	got, err := CustomResourceListHandler(crd.Name, crd, list, tpo.link)
+	got, err := CustomResourceListHandler(crd.Name, crd, list, tpo.link, false)
 	require.NoError(t, err)
 
 	expected := component.NewTableWithRows(

--- a/internal/modules/overview/printer/daemonset.go
+++ b/internal/modules/overview/printer/daemonset.go
@@ -23,7 +23,7 @@ func DaemonSetListHandler(_ context.Context, list *appsv1.DaemonSetList, opts Op
 
 	cols := component.NewTableCols("Name", "Labels", "Desired", "Current", "Ready",
 		"Up-To-Date", "Age", "Node Selector")
-	table := component.NewTable("Daemon Sets", cols)
+	table := component.NewTable("Daemon Sets", "We couldn't find any daemon sets!", cols)
 
 	for _, daemonSet := range list.Items {
 		row := component.TableRow{}
@@ -80,7 +80,7 @@ func printDaemonSetConfig(daemonSet *appsv1.DaemonSet) (*component.Summary, erro
 		return nil, errors.New("daemon set is nil")
 	}
 
-	var sections component.SummarySections
+	sections := component.SummarySections{}
 
 	rollingUpdate := daemonSet.Spec.UpdateStrategy.RollingUpdate
 	if rollingUpdate != nil {
@@ -112,7 +112,7 @@ func printDaemonSetStatus(daemonSet *appsv1.DaemonSet) (*component.Summary, erro
 		return nil, errors.New("daemon set is nil")
 	}
 
-	var sections component.SummarySections
+	sections := component.SummarySections{}
 
 	status := daemonSet.Status
 	sections.AddText("Current Number Scheduled", fmt.Sprint(status.CurrentNumberScheduled))

--- a/internal/modules/overview/printer/daemonset_test.go
+++ b/internal/modules/overview/printer/daemonset_test.go
@@ -48,7 +48,7 @@ func Test_DaemonSetListHandler(t *testing.T) {
 
 	cols := component.NewTableCols("Name", "Labels", "Desired", "Current", "Ready",
 		"Up-To-Date", "Age", "Node Selector")
-	expected := component.NewTable("Daemon Sets", cols)
+	expected := component.NewTable("Daemon Sets", "We couldn't find any daemon sets!", cols)
 	expected.Add(component.TableRow{
 		"Name":          component.NewLink("", object.Name, "/path"),
 		"Labels":        component.NewLabels(labels),
@@ -60,7 +60,7 @@ func Test_DaemonSetListHandler(t *testing.T) {
 		"Node Selector": component.NewSelectors(nil),
 	})
 
-	assert.Equal(t, expected, got)
+	component.AssertEqual(t, expected, got)
 }
 
 func Test_printDaemonSetConfig(t *testing.T) {
@@ -81,7 +81,7 @@ func Test_printDaemonSetConfig(t *testing.T) {
 	got, err := printDaemonSetConfig(object)
 	require.NoError(t, err)
 
-	var sections component.SummarySections
+	sections := component.SummarySections{}
 	sections.AddText("Update Strategy", "Max Unavailable 1")
 	sections.AddText("Revision History Limit", "10")
 	sections.Add("Selectors", printSelectorMap(labels))
@@ -98,7 +98,7 @@ func Test_printDaemonSetSummary(t *testing.T) {
 	got, err := printDaemonSetStatus(object)
 	require.NoError(t, err)
 
-	var sections component.SummarySections
+	sections := component.SummarySections{}
 	sections.AddText("Current Number Scheduled", "1")
 	sections.AddText("Desired Number Scheduled", "1")
 	sections.AddText("Number Available", "1")

--- a/internal/modules/overview/printer/deployment.go
+++ b/internal/modules/overview/printer/deployment.go
@@ -284,7 +284,7 @@ func deploymentPods(ctx context.Context, deployment *appsv1.Deployment, options 
 		Selector:   &selector,
 	}
 
-	list, err := objectStore.List(ctx, key)
+	list, _, err := objectStore.List(ctx, key)
 	if err != nil {
 		return nil, errors.Wrapf(err, "list all objects for key %s", key)
 	}

--- a/internal/modules/overview/printer/deployment.go
+++ b/internal/modules/overview/printer/deployment.go
@@ -30,7 +30,7 @@ func DeploymentListHandler(_ context.Context, list *appsv1.DeploymentList, opts 
 	}
 
 	cols := component.NewTableCols("Name", "Labels", "Status", "Age", "Containers", "Selector")
-	tbl := component.NewTable("Deployments", cols)
+	tbl := component.NewTable("Deployments", "We couldn't find any deployments!", cols)
 
 	for _, d := range list.Items {
 		row := component.TableRow{}
@@ -136,7 +136,7 @@ func deploymentConditions(deployment *appsv1.Deployment) (component.Component, e
 		return nil, errors.New("unable to generate conditions from a nil deployment")
 	}
 
-	table := component.NewTable("Conditions", deploymentConditionColumns)
+	table := component.NewTable("Conditions", "There are no deployment conditions!", deploymentConditionColumns)
 
 	for _, condition := range deployment.Status.Conditions {
 		row := component.TableRow{

--- a/internal/modules/overview/printer/deployment_test.go
+++ b/internal/modules/overview/printer/deployment_test.go
@@ -97,7 +97,7 @@ func Test_DeploymentListHandler(t *testing.T) {
 	containers.Add("kuard", "gcr.io/kuar-demo/kuard-amd64:1")
 
 	cols := component.NewTableCols("Name", "Labels", "Status", "Age", "Containers", "Selector")
-	expected := component.NewTable("Deployments", cols)
+	expected := component.NewTable("Deployments", "We couldn't find any deployments!", cols)
 	expected.Add(component.TableRow{
 		"Name":       component.NewLink("", "deployment", "/path"),
 		"Labels":     component.NewLabels(objectLabels),
@@ -107,7 +107,7 @@ func Test_DeploymentListHandler(t *testing.T) {
 		"Containers": containers,
 	})
 
-	assert.Equal(t, expected, got)
+	component.AssertEqual(t, expected, got)
 }
 
 func Test_deploymentConfiguration(t *testing.T) {
@@ -285,7 +285,7 @@ func Test_deploymentConditions(t *testing.T) {
 	got, err := deploymentConditions(deployment)
 	require.NoError(t, err)
 
-	expected := component.NewTableWithRows("Conditions", deploymentConditionColumns, []component.TableRow{
+	expected := component.NewTableWithRows("Conditions", "There are no deployment conditions!", deploymentConditionColumns, []component.TableRow{
 		{
 			"Type":            component.NewText("type1"),
 			"Reason":          component.NewText("reason1"),
@@ -343,7 +343,7 @@ func Test_deploymentPods(t *testing.T) {
 	got, err := deploymentPods(ctx, deployment, printOptions)
 	require.NoError(t, err)
 
-	expected := component.NewTableWithRows("Pods", podColsWithOutLabels, []component.TableRow{
+	expected := component.NewTableWithRows("Pods", "We couldn't find any pods!", podColsWithOutLabels, []component.TableRow{
 		{
 			"Name":     component.NewLink("", pod.Name, "/pod"),
 			"Age":      component.NewTimestamp(now),

--- a/internal/modules/overview/printer/deployment_test.go
+++ b/internal/modules/overview/printer/deployment_test.go
@@ -336,7 +336,7 @@ func Test_deploymentPods(t *testing.T) {
 	}
 	tpo.objectStore.EXPECT().
 		List(gomock.Any(), key).
-		Return(testutil.ToUnstructuredList(t, pod), nil)
+		Return(testutil.ToUnstructuredList(t, pod), false, nil)
 
 	ctx := context.Background()
 

--- a/internal/modules/overview/printer/double_setup_test.go
+++ b/internal/modules/overview/printer/double_setup_test.go
@@ -37,7 +37,7 @@ func mockObjectsEvents(t *testing.T, appObjectStore *storefake.MockStore, namesp
 
 	appObjectStore.EXPECT().
 		List(gomock.Any(), key).
-		Return(objects, nil).
+		Return(objects, false, nil).
 		AnyTimes()
 }
 

--- a/internal/modules/overview/printer/event.go
+++ b/internal/modules/overview/printer/event.go
@@ -237,7 +237,7 @@ func eventsForObject(ctx context.Context, object runtime.Object, o store.Store) 
 		Kind:       "Event",
 	}
 
-	list, err := o.List(ctx, key)
+	list, _, err := o.List(ctx, key)
 	if err != nil {
 		return nil, errors.Wrap(err, "list events for object")
 	}

--- a/internal/modules/overview/printer/event.go
+++ b/internal/modules/overview/printer/event.go
@@ -33,7 +33,7 @@ func EventListHandler(ctx context.Context, list *corev1.EventList, opts Options)
 
 	cols := component.NewTableCols("Kind", "Message", "Reason", "Type",
 		"First Seen", "Last Seen")
-	table := component.NewTable("Events", cols)
+	table := component.NewTable("Events", "We couldn't find any events!", cols)
 
 	for _, event := range list.Items {
 		row := component.TableRow{}
@@ -154,7 +154,7 @@ func PrintEvents(list *corev1.EventList, opts Options) (component.Component, err
 		return nil, errors.New("nil list")
 	}
 
-	table := component.NewTable("Events", objectEventCols)
+	table := component.NewTable("Events", "There are no events!", objectEventCols)
 
 	for _, event := range list.Items {
 		row := component.TableRow{}

--- a/internal/modules/overview/printer/event_test.go
+++ b/internal/modules/overview/printer/event_test.go
@@ -87,7 +87,7 @@ func Test_EventListHandler(t *testing.T) {
 
 	cols := component.NewTableCols("Kind", "Message", "Reason", "Type",
 		"First Seen", "Last Seen")
-	expected := component.NewTableWithRows("Events", cols, []component.TableRow{
+	expected := component.NewTableWithRows("Events", "We couldn't find any events!", cols, []component.TableRow{
 		{
 			"Kind":       component.NewLink("", "d1 (1234)", "/content/overview/namespace/default/workloads/deployments/d1"),
 			"Message":    component.NewLink("", "message", "/event2"),
@@ -177,7 +177,7 @@ func Test_ReplicaSetEvents(t *testing.T) {
 	got, err := PrintEvents(object, printOptions)
 	require.NoError(t, err)
 
-	expected := component.NewTable("Events", objectEventCols)
+	expected := component.NewTable("Events", "There are no events!", objectEventCols)
 
 	expected.Add(component.TableRow{
 		"Message":    component.NewText("Created pod: frontend-97k6z"),
@@ -209,7 +209,7 @@ func Test_ReplicaSetEvents(t *testing.T) {
 		"Count":      component.NewText("1"),
 	})
 
-	assert.Equal(t, expected, got)
+	component.AssertEqual(t, expected, got)
 }
 
 func Test_EventHandler(t *testing.T) {

--- a/internal/modules/overview/printer/event_test.go
+++ b/internal/modules/overview/printer/event_test.go
@@ -346,7 +346,7 @@ func Test_eventsForObject(t *testing.T) {
 		},
 	}...)
 
-	o.EXPECT().List(gomock.Any(), gomock.Eq(key)).Return(events, nil)
+	o.EXPECT().List(gomock.Any(), gomock.Eq(key)).Return(events, false, nil)
 
 	ctx := context.Background()
 	got, err := eventsForObject(ctx, object, o)

--- a/internal/modules/overview/printer/ingress.go
+++ b/internal/modules/overview/printer/ingress.go
@@ -24,7 +24,7 @@ func IngressListHandler(_ context.Context, list *extv1beta1.IngressList, options
 	}
 
 	cols := component.NewTableCols("Name", "Labels", "Hosts", "Address", "Ports", "Age")
-	table := component.NewTable("Ingresses", cols)
+	table := component.NewTable("Ingresses", "We couldn't find any ingresses!", cols)
 
 	for _, ingress := range list.Items {
 		ports := "80"
@@ -103,7 +103,7 @@ func printRulesForIngress(ingress *extv1beta1.Ingress, options Options) (compone
 	}
 
 	cols := component.NewTableCols("Host", "Path", "Backends")
-	table := component.NewTable("Rules", cols)
+	table := component.NewTable("Rules", "There are no rules defined!", cols)
 
 	ruleCount := 0
 	for _, rule := range ingress.Spec.Rules {

--- a/internal/modules/overview/printer/ingress_test.go
+++ b/internal/modules/overview/printer/ingress_test.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	extv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -56,7 +55,7 @@ func Test_IngressListHandler(t *testing.T) {
 		{
 			name: "in general",
 			list: list,
-			expected: component.NewTableWithRows("Ingresses", cols,
+			expected: component.NewTableWithRows("Ingresses", "We couldn't find any ingresses!", cols,
 				[]component.TableRow{
 					{
 						"Name":    component.NewLink("", "ingress", "/ingress"),
@@ -71,7 +70,7 @@ func Test_IngressListHandler(t *testing.T) {
 		{
 			name: "with TLS",
 			list: tlsList,
-			expected: component.NewTableWithRows("Ingresses", cols,
+			expected: component.NewTableWithRows("Ingresses", "We couldn't find any ingresses!", cols,
 				[]component.TableRow{
 					{
 						"Name":    component.NewLink("", "ingress", "/ingress"),
@@ -111,7 +110,7 @@ func Test_IngressListHandler(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			assert.Equal(t, tc.expected, got)
+			component.AssertEqual(t, tc.expected, got)
 
 		})
 	}
@@ -226,7 +225,7 @@ func Test_printIngressHosts(t *testing.T) {
 		{
 			name:   "in general",
 			object: object,
-			expected: component.NewTableWithRows("Rules", cols, []component.TableRow{
+			expected: component.NewTableWithRows("Rules", "There are no rules defined!", cols, []component.TableRow{
 				{
 					"Backends": component.NewLink("", "service", "/service"),
 					"Host":     component.NewText("*"),
@@ -237,7 +236,7 @@ func Test_printIngressHosts(t *testing.T) {
 		{
 			name:   "with rules",
 			object: objectWithRules,
-			expected: component.NewTableWithRows("Rules", cols, []component.TableRow{
+			expected: component.NewTableWithRows("Rules", "There are no rules defined!", cols, []component.TableRow{
 				{
 					"Backends": component.NewLink("", "service", "/service"),
 					"Host":     component.NewText("*"),

--- a/internal/modules/overview/printer/job.go
+++ b/internal/modules/overview/printer/job.go
@@ -29,7 +29,7 @@ func JobListHandler(_ context.Context, list *batchv1.JobList, opts Options) (com
 		return nil, errors.New("job list is nil")
 	}
 
-	table := component.NewTable("Jobs", JobCols)
+	table := component.NewTable("Jobs", "We couldn't find any jobs!", JobCols)
 
 	for _, job := range list.Items {
 		row := component.TableRow{}
@@ -121,7 +121,7 @@ func createJobStatus(job batchv1.Job) (*component.Summary, error) {
 func createJobConditions(conditions []batchv1.JobCondition) (*component.Table, error) {
 	cols := component.NewTableCols("Type", "Last Probe", "Last Transition",
 		"Status", "Message", "Reason")
-	table := component.NewTable("Conditions", cols)
+	table := component.NewTable("Conditions", "There are no job conditions!", cols)
 
 	for _, condition := range conditions {
 		row := component.TableRow{}

--- a/internal/modules/overview/printer/job.go
+++ b/internal/modules/overview/printer/job.go
@@ -173,7 +173,7 @@ func createJobListView(ctx context.Context, object runtime.Object, options Optio
 		Kind:       "Job",
 	}
 
-	list, err := objectStore.List(ctx, key)
+	list, _, err := objectStore.List(ctx, key)
 	if err != nil {
 		return nil, errors.Wrapf(err, "list all objects for key %+v", key)
 	}

--- a/internal/modules/overview/printer/job_test.go
+++ b/internal/modules/overview/printer/job_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	batchv1 "k8s.io/api/batch/v1"
 
@@ -59,7 +58,7 @@ func Test_JobListHandler(t *testing.T) {
 	got, err := JobListHandler(ctx, validJobList, printOptions)
 	require.NoError(t, err)
 
-	expected := component.NewTable("Jobs", JobCols)
+	expected := component.NewTable("Jobs", "We couldn't find any jobs!", JobCols)
 	expected.Add(component.TableRow{
 		"Name":        component.NewLink("", "job", "/job"),
 		"Labels":      component.NewLabels(validJobLabels),
@@ -68,5 +67,5 @@ func Test_JobListHandler(t *testing.T) {
 		"Age":         component.NewTimestamp(validJobCreationTime),
 	})
 
-	assert.Equal(t, expected, got)
+	component.AssertEqual(t, expected, got)
 }

--- a/internal/modules/overview/printer/node.go
+++ b/internal/modules/overview/printer/node.go
@@ -35,7 +35,7 @@ func NodeListHandler(ctx context.Context, list *corev1.NodeList, options Options
 		return nil, errors.New("node list is nil")
 	}
 
-	table := component.NewTable("Nodes", nodeListColumns)
+	table := component.NewTable("Nodes", "We couldn't find any nodes!", nodeListColumns)
 
 	for _, node := range list.Items {
 		row := component.TableRow{}
@@ -134,7 +134,7 @@ func nodeResources(node *corev1.Node) (component.Component, error) {
 		return nil, errors.New("nil nodes don't have resources")
 	}
 
-	table := component.NewTable("Resources", nodeResourcesColumns)
+	table := component.NewTable("Resources", "There are no resources!", nodeResourcesColumns)
 
 	allocatable := parseResourceList(node.Status.Allocatable)
 	capacity := parseResourceList(node.Status.Capacity)
@@ -170,7 +170,7 @@ var (
 )
 
 func nodeAddresses(node *corev1.Node) (component.Component, error) {
-	table := component.NewTable("Addresses", nodeAddressesColumns)
+	table := component.NewTable("Addresses", "There are no addresses!", nodeAddressesColumns)
 
 	for _, address := range node.Status.Addresses {
 		row := component.TableRow{}
@@ -304,7 +304,7 @@ func nodeConditions(node *corev1.Node) (component.Component, error) {
 		return nil, errors.New("cannot generate conditions for nil node")
 	}
 
-	table := component.NewTable("Conditions", nodeConditionsColumns)
+	table := component.NewTable("Conditions", "There are no node conditions!", nodeConditionsColumns)
 
 	for _, condition := range node.Status.Conditions {
 		row := component.TableRow{
@@ -333,7 +333,7 @@ func nodeImages(node *corev1.Node) (component.Component, error) {
 		return nil, errors.New("cannot generate images for nil node")
 	}
 
-	table := component.NewTable("Images", nodeImagesColumns)
+	table := component.NewTable("Images", "There are no images!", nodeImagesColumns)
 
 	for _, containerImage := range node.Status.Images {
 		row := component.TableRow{

--- a/internal/modules/overview/printer/node_test.go
+++ b/internal/modules/overview/printer/node_test.go
@@ -36,7 +36,7 @@ func TestNodeListHandler(t *testing.T) {
 	got, err := NodeListHandler(ctx, list, printOptions)
 	require.NoError(t, err)
 
-	expected := component.NewTableWithRows("Nodes", nodeListColumns, []component.TableRow{
+	expected := component.NewTableWithRows("Nodes", "We couldn't find any nodes!", nodeListColumns, []component.TableRow{
 		{
 			"Age":     component.NewTimestamp(node.CreationTimestamp.Time),
 			"Name":    component.NewLink("", "node-1", "/node"),
@@ -66,7 +66,7 @@ func Test_nodeAddresses(t *testing.T) {
 	got, err := nodeAddresses(node)
 	require.NoError(t, err)
 
-	expected := component.NewTableWithRows("Addresses", nodeAddressesColumns, []component.TableRow{
+	expected := component.NewTableWithRows("Addresses", "There are no addresses!", nodeAddressesColumns, []component.TableRow{
 		{
 			"Type":    component.NewText("Hostname"),
 			"Address": component.NewText("host.local"),
@@ -102,7 +102,7 @@ func Test_nodeResources(t *testing.T) {
 	got, err := nodeResources(node)
 	require.NoError(t, err)
 
-	expected := component.NewTableWithRows("Resources", nodeResourcesColumns, []component.TableRow{
+	expected := component.NewTableWithRows("Resources", "There are no resources!", nodeResourcesColumns, []component.TableRow{
 		{
 			"Key":         component.NewText("CPU"),
 			"Capacity":    component.NewText("1"),
@@ -145,7 +145,7 @@ func Test_nodeConditions(t *testing.T) {
 	got, err := nodeConditions(node)
 	require.NoError(t, err)
 
-	expected := component.NewTableWithRows("Conditions", nodeConditionsColumns, []component.TableRow{
+	expected := component.NewTableWithRows("Conditions", "There are no node conditions!", nodeConditionsColumns, []component.TableRow{
 		{
 			"Type":            component.NewText("type"),
 			"Reason":          component.NewText("reason"),
@@ -176,7 +176,7 @@ func Test_nodeImages(t *testing.T) {
 	got, err := nodeImages(node)
 	require.NoError(t, err)
 
-	expected := component.NewTableWithRows("Images", nodeImagesColumns, []component.TableRow{
+	expected := component.NewTableWithRows("Images", "There are no images!", nodeImagesColumns, []component.TableRow{
 		{
 			"Names": component.NewMarkdownText("a"),
 			"Size":  component.NewText("10"),

--- a/internal/modules/overview/printer/persistentvolumeclaim.go
+++ b/internal/modules/overview/printer/persistentvolumeclaim.go
@@ -23,7 +23,8 @@ func PersistentVolumeClaimListHandler(ctx context.Context, list *corev1.Persiste
 	}
 
 	cols := component.NewTableCols("Name", "Status", "Volume", "Capacity", "Access Modes", "Storage Class", "Age")
-	tbl := component.NewTable("Persistent Volume Claims", cols)
+	tbl := component.NewTable("Persistent Volume Claims",
+		"We couldn't find any persistent volume claims!", cols)
 
 	for _, persistentVolumeClaim := range list.Items {
 		row := component.TableRow{}

--- a/internal/modules/overview/printer/persistentvolumeclaim_test.go
+++ b/internal/modules/overview/printer/persistentvolumeclaim_test.go
@@ -49,7 +49,7 @@ func Test_PersistentVolumeListHandler(t *testing.T) {
 
 	cols := component.NewTableCols("Name", "Status", "Volume", "Capacity", "Access Modes",
 		"Storage Class", "Age")
-	expected := component.NewTable("Persistent Volume Claims", cols)
+	expected := component.NewTable("Persistent Volume Claims", "We couldn't find any persistent volume claims!", cols)
 	expected.Add(component.TableRow{
 		"Name":          component.NewLink("", object.Name, "/pvc"),
 		"Status":        component.NewText("Bound"),
@@ -60,7 +60,7 @@ func Test_PersistentVolumeListHandler(t *testing.T) {
 		"Age":           component.NewTimestamp(now),
 	})
 
-	assert.Equal(t, expected, got)
+	component.AssertEqual(t, expected, got)
 }
 
 func Test_printPersistentVolumeClaimConfig(t *testing.T) {

--- a/internal/modules/overview/printer/pod.go
+++ b/internal/modules/overview/printer/pod.go
@@ -42,7 +42,7 @@ func PodListHandler(_ context.Context, list *corev1.PodList, opts Options) (comp
 		cols = podColsWithOutLabels
 	}
 
-	tbl := component.NewTable("Pods", cols)
+	table := component.NewTable("Pods", "We couldn't find any pods!", cols)
 
 	for i := range list.Items {
 		if list.Items[i].Status.Phase == corev1.PodSucceeded {
@@ -90,12 +90,12 @@ func PodListHandler(_ context.Context, list *corev1.PodList, opts Options) (comp
 		ts := list.Items[i].CreationTimestamp.Time
 		row["Age"] = component.NewTimestamp(ts)
 
-		tbl.Add(row)
+		table.Add(row)
 	}
 
-	tbl.Sort("Name", false)
+	table.Sort("Name", false)
 
-	return tbl, nil
+	return table, nil
 }
 
 func podNode(pod *corev1.Pod, linkGenerator link.Interface) (component.Component, error) {
@@ -523,7 +523,7 @@ func createPodConditionsView(pod *corev1.Pod) (component.Component, error) {
 	}
 
 	cols := component.NewTableCols("Type", "Last Transition Time", "Message", "Reason")
-	table := component.NewTable("Pod Conditions", cols)
+	table := component.NewTable("Pod Conditions", "There are no pod conditions!", cols)
 
 	for _, condition := range pod.Status.Conditions {
 		row := component.TableRow{}

--- a/internal/modules/overview/printer/pod.go
+++ b/internal/modules/overview/printer/pod.go
@@ -327,7 +327,7 @@ func listPods(ctx context.Context, namespace string, selector *metav1.LabelSelec
 }
 
 func loadPods(ctx context.Context, key store.Key, o store.Store, labelSelector *metav1.LabelSelector) ([]*corev1.Pod, error) {
-	objects, err := o.List(ctx, key)
+	objects, _, err := o.List(ctx, key)
 	if err != nil {
 		return nil, err
 	}
@@ -454,7 +454,7 @@ func createPodListView(ctx context.Context, object runtime.Object, options Optio
 		Kind:       "Pod",
 	}
 
-	list, err := objectStore.List(ctx, key)
+	list, _, err := objectStore.List(ctx, key)
 	if err != nil {
 		return nil, errors.Wrapf(err, "list all objects for key %+v", key)
 	}

--- a/internal/modules/overview/printer/pod_test.go
+++ b/internal/modules/overview/printer/pod_test.go
@@ -143,7 +143,7 @@ func Test_PodHandler(t *testing.T) {
 		Kind:       "Event",
 	}
 	eventList := &unstructured.UnstructuredList{}
-	tpo.objectStore.EXPECT().List(gomock.Any(), gomock.Eq(eventKey)).Return(eventList, nil)
+	tpo.objectStore.EXPECT().List(gomock.Any(), gomock.Eq(eventKey)).Return(eventList, false, nil)
 
 	ctx := context.Background()
 	got, err := PodHandler(ctx, sidecar, printOptions)

--- a/internal/modules/overview/printer/pod_test.go
+++ b/internal/modules/overview/printer/pod_test.go
@@ -84,7 +84,7 @@ func Test_PodListHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	cols := component.NewTableCols("Name", "Labels", "Ready", "Phase", "Restarts", "Node", "Age")
-	expected := component.NewTable("Pods", cols)
+	expected := component.NewTable("Pods", "We couldn't find any pods!", cols)
 	expected.Add(component.TableRow{
 		"Name":     component.NewLink("", "pod", "/pod"),
 		"Labels":   component.NewLabels(labels),
@@ -170,7 +170,7 @@ func Test_PodHandler(t *testing.T) {
 	metadataSummary := component.NewSummary("Metadata", metadataSections...)
 
 	conditionsCols := component.NewTableCols("Type", "Last Transition Time", "Message", "Reason")
-	conditionTable := component.NewTable("Pod Conditions", conditionsCols)
+	conditionTable := component.NewTable("Pod Conditions", "There are no pod conditions!", conditionsCols)
 
 	container1Sections := component.SummarySections{
 		{Header: "Image", Content: component.NewText("nginx:1.15")},
@@ -186,13 +186,13 @@ func Test_PodHandler(t *testing.T) {
 	container2Summary := component.NewSummary("Container kuard", container2Sections...)
 
 	volumeCols := component.NewTableCols("Name", "Kind", "Description")
-	volumeTable := component.NewTable("Volumes", volumeCols)
+	volumeTable := component.NewTable("Volumes", "There are no volumes!", volumeCols)
 
 	taintCols := component.NewTableCols("Description")
-	taintTable := component.NewTable("Taints and Tolerations", taintCols)
+	taintTable := component.NewTable("Taints and Tolerations", "There are no taints or tolerations!", taintCols)
 
 	affinityCols := component.NewTableCols("Type", "Description")
-	affinityTable := component.NewTable("Affinities and Anti-Affinities", affinityCols)
+	affinityTable := component.NewTable("Affinities and Anti-Affinities", "There are no affinities or anti-affinities!", affinityCols)
 
 	expected := component.NewFlexLayout("Summary")
 	expected.AddSections(
@@ -273,7 +273,7 @@ func TestPodListHandler_sorted(t *testing.T) {
 	require.NoError(t, err)
 
 	cols := component.NewTableCols("Name", "Labels", "Ready", "Phase", "Restarts", "Node", "Age")
-	expected := component.NewTable("Pods", cols)
+	expected := component.NewTable("Pods", "We couldn't find any pods!", cols)
 	expected.Add(component.TableRow{
 		"Name":     component.NewLink("", "pod1", "/pod1"),
 		"Labels":   component.NewLabels(make(map[string]string)),
@@ -445,7 +445,7 @@ func Test_createPodConditionsView(t *testing.T) {
 	require.NoError(t, err)
 
 	cols := component.NewTableCols("Type", "Last Transition Time", "Message", "Reason")
-	expected := component.NewTable("Pod Conditions", cols)
+	expected := component.NewTable("Pod Conditions", "There are no pod conditions!", cols)
 	expected.Add([]component.TableRow{
 		{
 			"Type":                 component.NewText("Initialized"),
@@ -455,7 +455,7 @@ func Test_createPodConditionsView(t *testing.T) {
 		},
 	}...)
 
-	assert.Equal(t, expected, got)
+	component.AssertEqual(t, expected, got)
 }
 
 func createPodWithPhase(name string, podLabels map[string]string, phase corev1.PodPhase, owner *metav1.OwnerReference) *corev1.Pod {

--- a/internal/modules/overview/printer/printer.go
+++ b/internal/modules/overview/printer/printer.go
@@ -166,7 +166,7 @@ func DefaultPrintFunc(_ context.Context, object runtime.Object, _ Options) (comp
 	gvk := schema.FromAPIVersionAndKind(desc[0], desc[1])
 	title = gvk.String()
 
-	table := component.NewTable(title, cols)
+	table := component.NewTable(title, "We couldn't find any objects!", cols)
 
 	items := m["items"].([]interface{})
 

--- a/internal/modules/overview/printer/printer_test.go
+++ b/internal/modules/overview/printer/printer_test.go
@@ -228,14 +228,14 @@ func Test_DefaultPrinter(t *testing.T) {
 	require.NoError(t, err)
 
 	cols := component.NewTableCols("Name", "Labels", "Age")
-	expected := component.NewTable("/v1, Kind=DeploymentList", cols)
+	expected := component.NewTable("/v1, Kind=DeploymentList", "We couldn't find any objects!", cols)
 	expected.Add(component.TableRow{
 		"Name":   component.NewText("deployment"),
 		"Labels": component.NewLabels(labels),
 		"Age":    component.NewTimestamp(now),
 	})
 
-	assert.Equal(t, expected, got)
+	component.AssertEqual(t, expected, got)
 }
 
 func Test_DefaultPrinter_invalid_object(t *testing.T) {

--- a/internal/modules/overview/printer/replicaset.go
+++ b/internal/modules/overview/printer/replicaset.go
@@ -25,7 +25,7 @@ func ReplicaSetListHandler(ctx context.Context, list *appsv1.ReplicaSetList, opt
 	}
 
 	cols := component.NewTableCols("Name", "Labels", "Status", "Age", "Containers", "Selector")
-	tbl := component.NewTable("ReplicaSets", cols)
+	tbl := component.NewTable("ReplicaSets", "We couldn't find any replica sets!", cols)
 
 	for _, rs := range list.Items {
 		row := component.TableRow{}

--- a/internal/modules/overview/printer/replicaset_test.go
+++ b/internal/modules/overview/printer/replicaset_test.go
@@ -92,7 +92,7 @@ func Test_ReplicaSetListHandler(t *testing.T) {
 	containers.Add("kuard", "gcr.io/kuar-demo/kuard-amd64:1")
 
 	cols := component.NewTableCols("Name", "Labels", "Status", "Age", "Containers", "Selector")
-	expected := component.NewTable("ReplicaSets", cols)
+	expected := component.NewTable("ReplicaSets", "We couldn't find any replica sets!", cols)
 	expected.Add(component.TableRow{
 		"Name":       component.NewLink("", "replicaset-test", "/replica-set"),
 		"Labels":     component.NewLabels(labels),
@@ -102,7 +102,7 @@ func Test_ReplicaSetListHandler(t *testing.T) {
 		"Containers": containers,
 	})
 
-	assert.Equal(t, expected, got)
+	component.AssertEqual(t, expected, got)
 }
 
 func TestReplicaSetConfiguration(t *testing.T) {

--- a/internal/modules/overview/printer/replicaset_test.go
+++ b/internal/modules/overview/printer/replicaset_test.go
@@ -231,7 +231,7 @@ func TestReplicaSetStatus(t *testing.T) {
 		Kind:       "Pod",
 	}
 
-	o.EXPECT().List(gomock.Any(), gomock.Eq(key)).Return(podList, nil).AnyTimes()
+	o.EXPECT().List(gomock.Any(), gomock.Eq(key)).Return(podList, false, nil).AnyTimes()
 
 	ctx := context.Background()
 	rsc := NewReplicaSetStatus(rs)

--- a/internal/modules/overview/printer/replicationcontroller.go
+++ b/internal/modules/overview/printer/replicationcontroller.go
@@ -24,7 +24,8 @@ func ReplicationControllerListHandler(ctx context.Context, list *corev1.Replicat
 	}
 
 	cols := component.NewTableCols("Name", "Labels", "Status", "Age", "Containers", "Selector")
-	tbl := component.NewTable("ReplicationControllers", cols)
+	tbl := component.NewTable("ReplicationControllers",
+		"We couldn't find any replication controllers!", cols)
 
 	for _, rc := range list.Items {
 		row := component.TableRow{}

--- a/internal/modules/overview/printer/replicationcontroller_test.go
+++ b/internal/modules/overview/printer/replicationcontroller_test.go
@@ -145,7 +145,7 @@ func TestReplicationControllerStatus(t *testing.T) {
 		Kind:       "Pod",
 	}
 
-	o.EXPECT().List(gomock.Any(), gomock.Eq(key)).Return(podList, nil)
+	o.EXPECT().List(gomock.Any(), gomock.Eq(key)).Return(podList, false, nil)
 	rcs := NewReplicationControllerStatus(replicationController)
 	ctx := context.Background()
 	got, err := rcs.Create(ctx, o)

--- a/internal/modules/overview/printer/replicationcontroller_test.go
+++ b/internal/modules/overview/printer/replicationcontroller_test.go
@@ -85,7 +85,7 @@ func Test_ReplicationControllerListHandler(t *testing.T) {
 	containers.Add("nginx", "nginx:1.15")
 
 	cols := component.NewTableCols("Name", "Labels", "Status", "Age", "Containers", "Selector")
-	expected := component.NewTable("ReplicationControllers", cols)
+	expected := component.NewTable("ReplicationControllers", "We couldn't find any replication controllers!", cols)
 	expected.Add(component.TableRow{
 		"Name":       component.NewLink("", "rc-test", "/rc"),
 		"Labels":     component.NewLabels(validReplicationControllerLabels),
@@ -95,7 +95,7 @@ func Test_ReplicationControllerListHandler(t *testing.T) {
 		"Selector":   component.NewSelectors([]component.Selector{component.NewLabelSelector("app", "myapp")}),
 	})
 
-	assert.Equal(t, expected, got)
+	component.AssertEqual(t, expected, got)
 }
 
 func TestReplicationControllerStatus(t *testing.T) {

--- a/internal/modules/overview/printer/role.go
+++ b/internal/modules/overview/printer/role.go
@@ -21,7 +21,7 @@ func RoleListHandler(_ context.Context, roleList *rbacv1.RoleList, options Optio
 	}
 
 	columns := component.NewTableCols("Name", "Age")
-	table := component.NewTable("Roles", columns)
+	table := component.NewTable("Roles", "We couldn't find any roles!", columns)
 
 	for _, role := range roleList.Items {
 		row := component.TableRow{}
@@ -90,7 +90,7 @@ func printRolePolicyRules(role *rbacv1.Role) (*component.Table, error) {
 	})
 
 	cols := component.NewTableCols("Resources", "Non-Resource URLs", "Resource Names", "Verbs")
-	tbl := component.NewTable("PolicyRules", cols)
+	tbl := component.NewTable("PolicyRules", "There are no policy rules!", cols)
 
 	for _, r := range rules {
 		row := component.TableRow{}

--- a/internal/modules/overview/printer/role_test.go
+++ b/internal/modules/overview/printer/role_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,13 +42,13 @@ func Test_RoleListHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	cols := component.NewTableCols("Name", "Age")
-	expected := component.NewTable("Roles", cols)
+	expected := component.NewTable("Roles", "We couldn't find any roles!", cols)
 	expected.Add(component.TableRow{
 		"Name": component.NewLink("", role.Name, "/role"),
 		"Age":  component.NewTimestamp(role.CreationTimestamp.Time),
 	})
 
-	assert.Equal(t, expected, observed)
+	component.AssertEqual(t, expected, observed)
 }
 
 func Test_printRoleConfig(t *testing.T) {
@@ -65,7 +64,7 @@ func Test_printRoleConfig(t *testing.T) {
 	sections.AddText("Name", role.Name)
 	expected := component.NewSummary("Configuration", sections...)
 
-	assert.Equal(t, expected, observed)
+	component.AssertEqual(t, expected, observed)
 }
 
 func Test_printRolePolicyRules(t *testing.T) {
@@ -78,7 +77,7 @@ func Test_printRolePolicyRules(t *testing.T) {
 	require.NoError(t, err)
 
 	cols := component.NewTableCols("Resources", "Non-Resource URLs", "Resource Names", "Verbs")
-	expected := component.NewTable("PolicyRules", cols)
+	expected := component.NewTable("PolicyRules", "There are no policy rules!", cols)
 
 	row := component.TableRow{}
 	row["Resources"] = component.NewText("pods")
@@ -88,5 +87,5 @@ func Test_printRolePolicyRules(t *testing.T) {
 
 	expected.Add(row)
 
-	assert.Equal(t, expected, observed)
+	component.AssertEqual(t, expected, observed)
 }

--- a/internal/modules/overview/printer/rolebinding.go
+++ b/internal/modules/overview/printer/rolebinding.go
@@ -21,7 +21,7 @@ func RoleBindingListHandler(ctx context.Context, roleBindingList *rbacv1.RoleBin
 	}
 
 	columns := component.NewTableCols("Name", "Age", "Role kind", "Role name")
-	table := component.NewTable("Role Bindings", columns)
+	table := component.NewTable("Role Bindings", "We couldn't find any role bindings!", columns)
 
 	for _, roleBinding := range roleBindingList.Items {
 		row := component.TableRow{}
@@ -107,7 +107,7 @@ func printRoleBindingSubjects(ctx context.Context, roleBinding *rbacv1.RoleBindi
 	}
 
 	columns := component.NewTableCols("Kind", "Name", "Namespace")
-	table := component.NewTable("Subjects", columns)
+	table := component.NewTable("Subjects", "There are no subjects!", columns)
 
 	for _, subject := range roleBinding.Subjects {
 		row := component.TableRow{}

--- a/internal/modules/overview/printer/rolebinding_test.go
+++ b/internal/modules/overview/printer/rolebinding_test.go
@@ -44,7 +44,7 @@ func Test_RoleBindingListHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	cols := component.NewTableCols("Name", "Age", "Role kind", "Role name")
-	expected := component.NewTable("Role Bindings", cols)
+	expected := component.NewTable("Role Bindings", "We couldn't find any role bindings!", cols)
 	expected.Add(component.TableRow{
 		"Name":      component.NewLink("", roleBinding.Name, "/role-binding"),
 		"Age":       component.NewTimestamp(now),
@@ -103,7 +103,7 @@ func Test_printRoleBindingSubjects(t *testing.T) {
 			observed, err := printRoleBindingSubjects(ctx, roleBinding, printOptions)
 			require.NoError(t, err)
 
-			expected := component.NewTableWithRows("Subjects",
+			expected := component.NewTableWithRows("Subjects", "There are no subjects!",
 				component.NewTableCols("Kind", "Name", "Namespace"),
 				[]component.TableRow{tc.expected})
 

--- a/internal/modules/overview/printer/secret.go
+++ b/internal/modules/overview/printer/secret.go
@@ -26,7 +26,7 @@ func SecretListHandler(ctx context.Context, list *corev1.SecretList, options Opt
 		return nil, errors.New("list of secrets is nil")
 	}
 
-	table := component.NewTable("Secrets", secretTableCols)
+	table := component.NewTable("Secrets", "We couldn't find any secrets!", secretTableCols)
 
 	for _, secret := range list.Items {
 		row := component.TableRow{}
@@ -86,7 +86,7 @@ func secretConfiguration(secret corev1.Secret) (*component.Summary, error) {
 }
 
 func secretData(secret corev1.Secret) (*component.Table, error) {
-	table := component.NewTable("Data", secretDataCols)
+	table := component.NewTable("Data", "This secret has no data!", secretDataCols)
 
 	for key := range secret.Data {
 		row := component.TableRow{}

--- a/internal/modules/overview/printer/secret_test.go
+++ b/internal/modules/overview/printer/secret_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -61,7 +60,7 @@ func Test_SecretListHandler(t *testing.T) {
 	got, err := SecretListHandler(ctx, object, printOptions)
 	require.NoError(t, err)
 
-	expected := component.NewTable("Secrets", secretTableCols)
+	expected := component.NewTable("Secrets", "We couldn't find any secrets!", secretTableCols)
 	expected.Add(component.TableRow{
 		"Name":   component.NewLink("", "secret", "/secret"),
 		"Labels": component.NewLabels(labels),
@@ -70,5 +69,5 @@ func Test_SecretListHandler(t *testing.T) {
 		"Age":    component.NewTimestamp(now),
 	})
 
-	assert.Equal(t, expected, got)
+	component.AssertEqual(t, expected, got)
 }

--- a/internal/modules/overview/printer/service.go
+++ b/internal/modules/overview/printer/service.go
@@ -25,7 +25,7 @@ func ServiceListHandler(_ context.Context, list *corev1.ServiceList, options Opt
 	}
 
 	cols := component.NewTableCols("Name", "Labels", "Type", "Cluster IP", "External IP", "Target Ports", "Age", "Selector")
-	tbl := component.NewTable("Services", cols)
+	tbl := component.NewTable("Services", "We couldn't find any services!", cols)
 
 	for _, s := range list.Items {
 		row := component.TableRow{}
@@ -215,7 +215,7 @@ func serviceEndpoints(ctx context.Context, options Options, service *corev1.Serv
 	}
 
 	cols := component.NewTableCols("Target", "IP", "Node Name")
-	table := component.NewTable("Endpoints", cols)
+	table := component.NewTable("Endpoints", "There are no endpoints!", cols)
 
 	endpoints := &corev1.Endpoints{}
 	if err := scheme.Scheme.Convert(object, endpoints, 0); err != nil {

--- a/internal/modules/overview/printer/service_test.go
+++ b/internal/modules/overview/printer/service_test.go
@@ -84,7 +84,7 @@ func Test_ServiceListHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	cols := component.NewTableCols("Name", "Labels", "Type", "Cluster IP", "External IP", "Target Ports", "Age", "Selector")
-	expected := component.NewTable("Services", cols)
+	expected := component.NewTable("Services", "We couldn't find any services!", cols)
 	expected.Add(component.TableRow{
 		"Name":         component.NewLink("", "service", "/service"),
 		"Labels":       component.NewLabels(labels),
@@ -96,7 +96,7 @@ func Test_ServiceListHandler(t *testing.T) {
 		"Selector":     component.NewSelectors([]component.Selector{component.NewLabelSelector("app", "myapp")}),
 	})
 
-	assert.Equal(t, expected, got)
+	component.AssertEqual(t, expected, got)
 }
 
 func Test_describeServiceConfiguration(t *testing.T) {
@@ -149,7 +149,7 @@ func Test_describeServiceConfiguration(t *testing.T) {
 	}
 
 	expected := component.NewSummary("Configuration", sections...)
-	assert.Equal(t, expected, got)
+	component.AssertEqual(t, expected, got)
 }
 
 func Test_serviceSummary(t *testing.T) {
@@ -185,7 +185,7 @@ func Test_serviceSummary(t *testing.T) {
 	}
 
 	expected := component.NewSummary("Status", sections...)
-	assert.Equal(t, expected, got)
+	component.AssertEqual(t, expected, got)
 }
 
 func Test_serviceEndpoints(t *testing.T) {
@@ -238,14 +238,14 @@ func Test_serviceEndpoints(t *testing.T) {
 	require.NoError(t, err)
 
 	cols := component.NewTableCols("Target", "IP", "Node Name")
-	expected := component.NewTable("Endpoints", cols)
+	expected := component.NewTable("Endpoints", "There are no endpoints!", cols)
 	expected.Add(component.TableRow{
 		"Target":    component.NewLink("", "pod", "/pod"),
 		"IP":        component.NewText("10.1.1.1"),
 		"Node Name": component.NewText("node"),
 	})
 
-	assert.Equal(t, expected, got)
+	component.AssertEqual(t, expected, got)
 }
 
 func Test_describeTargetPort(t *testing.T) {

--- a/internal/modules/overview/printer/serviceaccount.go
+++ b/internal/modules/overview/printer/serviceaccount.go
@@ -174,7 +174,7 @@ func serviceAccountTokens(ctx context.Context, serviceAccount corev1.ServiceAcco
 		APIVersion: "v1",
 		Kind:       "Secret",
 	}
-	secretList, err := o.List(ctx, key)
+	secretList, _, err := o.List(ctx, key)
 	if err != nil {
 		return nil, errors.Wrap(err, "find secrets for service account")
 	}
@@ -291,7 +291,7 @@ func (s *serviceAccountPolicyRules) listRoleBindings() ([]rbacv1.RoleRef, error)
 		Kind:       "RoleBinding",
 	}
 
-	objects, err := s.appObjectStore.List(s.ctx, roleBindingKey)
+	objects, _, err := s.appObjectStore.List(s.ctx, roleBindingKey)
 	if err != nil {
 		return nil, err
 	}
@@ -318,7 +318,7 @@ func (s *serviceAccountPolicyRules) listClusterRoleBindings() ([]rbacv1.RoleRef,
 		Kind:       "ClusterRoleBinding",
 	}
 
-	objects, err := s.appObjectStore.List(s.ctx, roleBindingKey)
+	objects, _, err := s.appObjectStore.List(s.ctx, roleBindingKey)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/modules/overview/printer/serviceaccount.go
+++ b/internal/modules/overview/printer/serviceaccount.go
@@ -25,7 +25,8 @@ func ServiceAccountListHandler(_ context.Context, list *corev1.ServiceAccountLis
 	}
 
 	cols := component.NewTableCols("Name", "Labels", "Secrets", "Age")
-	table := component.NewTable("Service Accounts", cols)
+	table := component.NewTable("Service Accounts",
+		"We couldn't find any service accounts!", cols)
 
 	for _, serviceAccount := range list.Items {
 		row := component.TableRow{}

--- a/internal/modules/overview/printer/serviceaccount_test.go
+++ b/internal/modules/overview/printer/serviceaccount_test.go
@@ -144,7 +144,7 @@ func Test_printServiceAccountConfig(t *testing.T) {
 	tpo.PathForGVK(object.Namespace, "v1", "Secret", "secret", "secret", "/secret")
 
 	tpo.objectStore.EXPECT().List(gomock.Any(), gomock.Eq(key)).
-		Return(testutil.ToUnstructuredList(t, testutil.ToUnstructured(t, secret)), nil)
+		Return(testutil.ToUnstructuredList(t, testutil.ToUnstructured(t, secret)), false, nil)
 
 	ctx := context.Background()
 	got, err := printServiceAccountConfig(ctx, *object, printOptions)
@@ -202,7 +202,7 @@ func Test_serviceAccountPolicyRules(t *testing.T) {
 
 	appObjectStore.EXPECT().
 		List(gomock.Any(), roleBindingKey).
-		Return(roleBindingObjects, nil)
+		Return(roleBindingObjects, false, nil)
 
 	clusterRoleBindingKey := store.Key{
 		APIVersion: "rbac.authorization.k8s.io/v1",
@@ -223,7 +223,7 @@ func Test_serviceAccountPolicyRules(t *testing.T) {
 
 	appObjectStore.EXPECT().
 		List(gomock.Any(), clusterRoleBindingKey).
-		Return(clusterRoleBindingObjects, nil)
+		Return(clusterRoleBindingObjects, false, nil)
 
 	role1Key, err := store.KeyFromObject(role1)
 	require.NoError(t, err)

--- a/internal/modules/overview/printer/serviceaccount_test.go
+++ b/internal/modules/overview/printer/serviceaccount_test.go
@@ -53,7 +53,7 @@ func Test_ServiceAccountListHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	cols := component.NewTableCols("Name", "Labels", "Secrets", "Age")
-	expected := component.NewTable("Service Accounts", cols)
+	expected := component.NewTable("Service Accounts", "We couldn't find any service accounts!", cols)
 	expected.Add(component.TableRow{
 		"Name":    component.NewLink("", object.Name, "/path"),
 		"Labels":  component.NewLabels(labels),
@@ -61,7 +61,7 @@ func Test_ServiceAccountListHandler(t *testing.T) {
 		"Age":     component.NewTimestamp(now),
 	})
 
-	assert.Equal(t, expected, got)
+	component.AssertEqual(t, expected, got)
 }
 
 func Test_serviceAccountHandler(t *testing.T) {
@@ -92,7 +92,7 @@ func Test_serviceAccountHandler(t *testing.T) {
 		return summaryConfig, nil
 	}
 
-	policyTable := component.NewTable("policyTable", component.NewTableCols("col1"))
+	policyTable := component.NewTable("policyTable", "", component.NewTableCols("col1"))
 	h.policyRulesFunc = func(ctx context.Context, serviceAccount corev1.ServiceAccount, appObjectStore store.Store) (*component.Table, error) {
 		return policyTable, nil
 	}

--- a/internal/modules/overview/printer/statefulset.go
+++ b/internal/modules/overview/printer/statefulset.go
@@ -22,7 +22,7 @@ func StatefulSetListHandler(_ context.Context, list *appsv1.StatefulSetList, opt
 	}
 
 	cols := component.NewTableCols("Name", "Labels", "Desired", "Current", "Age", "Selector")
-	tbl := component.NewTable("StatefulSets", cols)
+	tbl := component.NewTable("StatefulSets", "We couldn't find any stateful sets!", cols)
 
 	for _, statefulSet := range list.Items {
 		row := component.TableRow{}

--- a/internal/modules/overview/printer/statefulset_test.go
+++ b/internal/modules/overview/printer/statefulset_test.go
@@ -144,7 +144,7 @@ func Test_StatefulSetStatus(t *testing.T) {
 		Kind:       "Pod",
 	}
 
-	tpo.objectStore.EXPECT().List(gomock.Any(), gomock.Eq(key)).Return(podList, nil)
+	tpo.objectStore.EXPECT().List(gomock.Any(), gomock.Eq(key)).Return(podList, false, nil)
 
 	stsc := NewStatefulSetStatus(sts)
 	ctx := context.Background()

--- a/internal/modules/overview/printer/statefulset_test.go
+++ b/internal/modules/overview/printer/statefulset_test.go
@@ -82,7 +82,7 @@ func Test_StatefulSetListHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	cols := component.NewTableCols("Name", "Labels", "Desired", "Current", "Age", "Selector")
-	expected := component.NewTable("StatefulSets", cols)
+	expected := component.NewTable("StatefulSets", "We couldn't find any stateful sets!", cols)
 	expected.Add(component.TableRow{
 		"Name":     component.NewLink("", "web", "/path"),
 		"Labels":   component.NewLabels(labels),

--- a/internal/modules/overview/printer/tolerations.go
+++ b/internal/modules/overview/printer/tolerations.go
@@ -29,7 +29,7 @@ type tolerationDescriber struct {
 
 func (td *tolerationDescriber) Create() (*component.Table, error) {
 	cols := component.NewTableCols("Description")
-	table := component.NewTable("Taints and Tolerations", cols)
+	table := component.NewTable("Taints and Tolerations", "There are no taints or tolerations!", cols)
 
 	for _, toleration := range td.podSpec.Tolerations {
 		msg, err := td.describe(toleration)

--- a/internal/modules/overview/printer/tolerations_test.go
+++ b/internal/modules/overview/printer/tolerations_test.go
@@ -10,7 +10,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/vmware/octant/internal/conversion"
@@ -19,7 +18,7 @@ import (
 
 func tolerationTable(descriptions ...string) *component.Table {
 	table := component.NewTableWithRows(
-		"Taints and Tolerations",
+		"Taints and Tolerations", "There are no taints or tolerations!",
 		component.NewTableCols("Description"),
 		[]component.TableRow{})
 
@@ -156,7 +155,7 @@ func Test_TolerationDescriber_Create(t *testing.T) {
 
 			require.NoError(t, err)
 
-			assert.Equal(t, tc.expected, got)
+			component.AssertEqual(t, tc.expected, got)
 		})
 	}
 }

--- a/internal/modules/overview/printer/volume.go
+++ b/internal/modules/overview/printer/volume.go
@@ -46,7 +46,7 @@ const (
 // printVolumes prints volumes as a table.
 func printVolumes(volumes []corev1.Volume) (component.Component, error) {
 	cols := component.NewTableCols("Name", "Kind", "Description")
-	table := component.NewTable("Volumes", cols)
+	table := component.NewTable("Volumes", "There are no volumes!", cols)
 
 	for _, volume := range volumes {
 		row := component.TableRow{}

--- a/internal/modules/overview/printer/volume_test.go
+++ b/internal/modules/overview/printer/volume_test.go
@@ -12,7 +12,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -422,10 +421,10 @@ func Test_printVolumes(t *testing.T) {
 			got, err := printVolumes([]corev1.Volume{tc.volume})
 			require.NoError(t, err)
 
-			expected := component.NewTableWithRows("Volumes",
+			expected := component.NewTableWithRows("Volumes", "There are no volumes!",
 				component.NewTableCols("Name", "Kind", "Description"),
 				[]component.TableRow{tc.expected})
-			assert.Equal(t, expected, got)
+			component.AssertEqual(t, expected, got)
 		})
 	}
 }

--- a/internal/objectstore/accessors.go
+++ b/internal/objectstore/accessors.go
@@ -3,11 +3,56 @@ package objectstore
 import (
 	"sync"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic/dynamicinformer"
+
+	"github.com/vmware/octant/pkg/store"
 )
+
+type informerSynced struct {
+	status map[string]bool
+
+	mu sync.RWMutex
+}
+
+func initInformerSynced() *informerSynced {
+	return &informerSynced{
+		status: make(map[string]bool),
+	}
+}
+
+func (c *informerSynced) setSynced(key store.Key, value bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.status[key.String()] = value
+}
+
+func (c *informerSynced) hasSynced(key store.Key) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	v, ok := c.status[key.String()]
+	if !ok {
+		return true
+	}
+
+	return v
+}
+
+func (c *informerSynced) hasSeen(key store.Key) bool {
+	_, ok := c.status[key.String()]
+	return ok
+}
+
+func (c *informerSynced) reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for key := range c.status {
+		delete(c.status, key)
+	}
+}
 
 // TODO: investigate sync.Map
 
@@ -121,117 +166,4 @@ func (c *seenGVKsCache) hasSeen(key string, groupVersionKind schema.GroupVersion
 	}
 
 	return seen
-}
-
-type cachedObjectsCache struct {
-	cachedObjects map[string]map[schema.GroupVersionKind]map[types.UID]*unstructured.Unstructured
-	mu            sync.RWMutex
-}
-
-func initCachedObjectsCache() *cachedObjectsCache {
-	return &cachedObjectsCache{
-		cachedObjects: make(map[string]map[schema.GroupVersionKind]map[types.UID]*unstructured.Unstructured),
-	}
-}
-
-func (c *cachedObjectsCache) list(key string, groupVersionKind schema.GroupVersionKind) []*unstructured.Unstructured {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	var list []*unstructured.Unstructured
-
-	gvkList, ok := c.cachedObjects[key]
-	if !ok {
-		return list
-	}
-
-	objectMap, ok := gvkList[groupVersionKind]
-	if !ok {
-		return list
-	}
-
-	for _, object := range objectMap {
-		list = append(list, object)
-	}
-
-	return list
-}
-
-func (c *cachedObjectsCache) update(ns string, groupVersionKind schema.GroupVersionKind, object *unstructured.Unstructured) {
-	if object == nil {
-		return
-	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	cur, ok := c.cachedObjects[ns]
-	if !ok {
-		cur = make(map[schema.GroupVersionKind]map[types.UID]*unstructured.Unstructured)
-	}
-
-	curGVK, ok := cur[groupVersionKind]
-	if !ok {
-		curGVK = make(map[types.UID]*unstructured.Unstructured)
-	}
-
-	curGVK[object.GetUID()] = object
-	cur[groupVersionKind] = curGVK
-	c.cachedObjects[ns] = cur
-}
-
-func (c *cachedObjectsCache) delete(ns string, groupVersionKind schema.GroupVersionKind, object *unstructured.Unstructured) {
-	if object == nil {
-		return
-	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	cur, ok := c.cachedObjects[ns]
-	if !ok {
-		return
-	}
-
-	curGVK, ok := cur[groupVersionKind]
-	if !ok {
-		return
-	}
-
-	delete(curGVK, object.GetUID())
-	cur[groupVersionKind] = curGVK
-	c.cachedObjects[ns] = cur
-}
-
-type watchedGVKsCache struct {
-	watchedGVKs map[string]map[schema.GroupVersionKind]bool
-	mu          sync.RWMutex
-}
-
-func initWatchedGVKsCache() *watchedGVKsCache {
-	return &watchedGVKsCache{
-		watchedGVKs: make(map[string]map[schema.GroupVersionKind]bool),
-	}
-}
-
-func (c *watchedGVKsCache) isWatched(key string, groupVersionKind schema.GroupVersionKind) bool {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	gvkMap, ok := c.watchedGVKs[key]
-	if !ok {
-		return false
-	}
-	return gvkMap[groupVersionKind]
-}
-
-func (c *watchedGVKsCache) setWatched(key string, groupVersionKind schema.GroupVersionKind) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	cur, ok := c.watchedGVKs[key]
-	if !ok {
-		cur = make(map[schema.GroupVersionKind]bool)
-	}
-
-	cur[groupVersionKind] = true
-	c.watchedGVKs[key] = cur
 }

--- a/internal/octant/factory.go
+++ b/internal/octant/factory.go
@@ -19,7 +19,7 @@ import (
 )
 
 // EntriesFunc is a function that can create navigation entries.
-type EntriesFunc func(ctx context.Context, prefix, namespace string, objectStore store.Store, wantsClusterScoped bool) ([]navigation.Navigation, error)
+type EntriesFunc func(ctx context.Context, prefix, namespace string, objectStore store.Store, wantsClusterScoped bool) ([]navigation.Navigation, bool, error)
 
 // NavigationEntries help construct navigation entries.
 type NavigationEntries struct {
@@ -112,11 +112,12 @@ func (nf *NavigationFactory) genNode(ctx context.Context, name string, childFn E
 	}
 
 	if childFn != nil {
-		children, err := childFn(ctx, node.Path, nf.namespace, nf.objectStore, wantsClusterScoped)
+		children, loading, err := childFn(ctx, node.Path, nf.namespace, nf.objectStore, wantsClusterScoped)
 		if err != nil {
 			return nil, err
 		}
 		node.Children = children
+		node.Loading = loading
 	}
 
 	return node, nil

--- a/internal/octant/object.go
+++ b/internal/octant/object.go
@@ -1,0 +1,1 @@
+package octant

--- a/internal/queryer/queryer.go
+++ b/internal/queryer/queryer.go
@@ -188,7 +188,7 @@ func (osq *ObjectStoreQueryer) Children(ctx context.Context, owner *unstructured
 
 	list := append(allowed[:0:0], allowed...)
 
-	crds, err := navigation.CustomResourceDefinitions(ctx, osq.objectStore)
+	crds, _, err := navigation.CustomResourceDefinitions(ctx, osq.objectStore)
 	if err == nil {
 		for _, crd := range crds {
 			for _, version := range crd.Spec.Versions {
@@ -256,7 +256,7 @@ func (osq *ObjectStoreQueryer) Children(ctx context.Context, owner *unstructured
 					return err
 				}
 				defer sem.Release(1)
-				objects, err := osq.objectStore.List(ctx, key)
+				objects, _, err := osq.objectStore.List(ctx, key)
 				if err != nil {
 					return errors.Wrapf(err, "unable to retrieve %+v", key)
 				}
@@ -327,7 +327,7 @@ func (osq *ObjectStoreQueryer) Events(ctx context.Context, object metav1.Object)
 		Kind:       "Event",
 	}
 
-	allEvents, err := osq.objectStore.List(ctx, key)
+	allEvents, _, err := osq.objectStore.List(ctx, key)
 	if err != nil {
 		return nil, err
 	}
@@ -362,7 +362,7 @@ func (osq *ObjectStoreQueryer) IngressesForService(ctx context.Context, service 
 		APIVersion: "extensions/v1beta1",
 		Kind:       "Ingress",
 	}
-	ul, err := osq.objectStore.List(ctx, key)
+	ul, _, err := osq.objectStore.List(ctx, key)
 	if err != nil {
 		return nil, errors.Wrap(err, "retrieving ingresses")
 	}
@@ -504,7 +504,7 @@ func (osq *ObjectStoreQueryer) PodsForService(ctx context.Context, service *core
 }
 
 func (osq *ObjectStoreQueryer) loadPods(ctx context.Context, key store.Key, labelSelector *metav1.LabelSelector) ([]*corev1.Pod, error) {
-	objects, err := osq.objectStore.List(ctx, key)
+	objects, _, err := osq.objectStore.List(ctx, key)
 	if err != nil {
 		return nil, err
 	}
@@ -585,7 +585,7 @@ func (osq *ObjectStoreQueryer) ServicesForPod(ctx context.Context, pod *corev1.P
 		APIVersion: "v1",
 		Kind:       "Service",
 	}
-	ul, err := osq.objectStore.List(ctx, key)
+	ul, _, err := osq.objectStore.List(ctx, key)
 	if err != nil {
 		return nil, errors.Wrap(err, "retrieving services")
 	}

--- a/internal/queryer/queryer_test.go
+++ b/internal/queryer/queryer_test.go
@@ -96,11 +96,11 @@ func TestCacheQueryer_Children(t *testing.T) {
 			setup: func(t *testing.T, o *storeFake.MockStore, disco *queryerFake.MockDiscoveryInterface) {
 				o.EXPECT().
 					List(gomock.Any(), gomock.Eq(deploymentKey)).
-					Return(testutil.ToUnstructuredList(t, deployment), nil)
+					Return(testutil.ToUnstructuredList(t, deployment), false, nil)
 
 				o.EXPECT().
 					List(gomock.Any(), gomock.Eq(rsKey)).
-					Return(testutil.ToUnstructuredList(t, rs), nil)
+					Return(testutil.ToUnstructuredList(t, rs), false, nil)
 
 				disco.EXPECT().
 					ServerPreferredResources().
@@ -132,11 +132,11 @@ func TestCacheQueryer_Children(t *testing.T) {
 			setup: func(t *testing.T, o *storeFake.MockStore, disco *queryerFake.MockDiscoveryInterface) {
 				o.EXPECT().
 					List(gomock.Any(), gomock.Eq(deploymentKey)).
-					Return(nil, errors.New("failed")).Times(1)
+					Return(nil, false, errors.New("failed")).Times(1)
 
 				o.EXPECT().
 					List(gomock.Any(), gomock.Eq(rsKey)).
-					Return(testutil.ToUnstructuredList(t, rs), nil)
+					Return(testutil.ToUnstructuredList(t, rs), false, nil)
 
 				disco.EXPECT().
 					ServerPreferredResources().
@@ -160,7 +160,7 @@ func TestCacheQueryer_Children(t *testing.T) {
 				APIVersion: "apiextensions.k8s.io/v1beta1",
 				Kind:       "CustomResourceDefinition",
 			}
-			o.EXPECT().List(gomock.Any(), crdKey).Return(&unstructured.UnstructuredList{}, nil).AnyTimes()
+			o.EXPECT().List(gomock.Any(), crdKey).Return(&unstructured.UnstructuredList{}, false, nil).AnyTimes()
 
 			if tc.setup != nil {
 				tc.setup(t, o, discovery)
@@ -217,7 +217,7 @@ func TestCacheQueryer_Events(t *testing.T) {
 				}
 				o.EXPECT().
 					List(gomock.Any(), gomock.Eq(key)).
-					Return(testutil.ToUnstructuredList(t, events[0], events[1], events[2]), nil)
+					Return(testutil.ToUnstructuredList(t, events[0], events[1], events[2]), false, nil)
 
 			},
 			expected: []string{"event-0", "event-1", "event-2"},
@@ -328,7 +328,7 @@ func TestCacheQueryer_IngressesForService(t *testing.T) {
 				}
 				o.EXPECT().
 					List(gomock.Any(), gomock.Eq(ingressesKey)).
-					Return(testutil.ToUnstructuredList(t, ingress1, ingress2, ingress3), nil)
+					Return(testutil.ToUnstructuredList(t, ingress1, ingress2, ingress3), false, nil)
 			},
 			expected: []*extv1beta1.Ingress{
 				ingress1, ingress2,
@@ -350,7 +350,7 @@ func TestCacheQueryer_IngressesForService(t *testing.T) {
 				}
 				o.EXPECT().
 					List(gomock.Any(), gomock.Eq(ingressesKey)).
-					Return(nil, errors.New("failed"))
+					Return(nil, false, errors.New("failed"))
 			},
 			isErr: true,
 		},
@@ -513,7 +513,7 @@ func TestCacheQueryer_PodsForService(t *testing.T) {
 				}
 				o.EXPECT().
 					List(gomock.Any(), gomock.Eq(key)).
-					Return(testutil.ToUnstructuredList(t, pod1, pod2), nil)
+					Return(testutil.ToUnstructuredList(t, pod1, pod2), false, nil)
 			},
 			expected: []*corev1.Pod{pod1},
 		},
@@ -533,7 +533,7 @@ func TestCacheQueryer_PodsForService(t *testing.T) {
 				}
 				o.EXPECT().
 					List(gomock.Any(), gomock.Eq(key)).
-					Return(nil, errors.New("failed"))
+					Return(nil, false, errors.New("failed"))
 			},
 			isErr: true,
 		},
@@ -779,7 +779,7 @@ func TestCacheQueryer_ServicesForPods(t *testing.T) {
 				}
 				o.EXPECT().
 					List(gomock.Any(), gomock.Eq(key)).
-					Return(testutil.ToUnstructuredList(t, service1, service2), nil)
+					Return(testutil.ToUnstructuredList(t, service1, service2), false, nil)
 			},
 			expected: []string{"service1"},
 		},
@@ -799,7 +799,7 @@ func TestCacheQueryer_ServicesForPods(t *testing.T) {
 				}
 				o.EXPECT().
 					List(gomock.Any(), gomock.Eq(key)).
-					Return(nil, errors.New("failed"))
+					Return(nil, false, errors.New("failed"))
 			},
 			isErr: true,
 		},

--- a/pkg/navigation/navigation.go
+++ b/pkg/navigation/navigation.go
@@ -20,7 +20,7 @@ import (
 	"github.com/vmware/octant/internal/log"
 	"github.com/vmware/octant/pkg/icon"
 	"github.com/vmware/octant/pkg/store"
-	octantunstructured "github.com/vmware/octant/thirdparty/unstructured"
+	octantUnstructured "github.com/vmware/octant/thirdparty/unstructured"
 )
 
 // Option is an option for configuring navigation.
@@ -45,6 +45,14 @@ func SetNavigationIcon(name string) Option {
 	}
 }
 
+// SetLoading sets the loading status for the navigation entry.
+func SetLoading(isLoading bool) Option {
+	return func(navigation *Navigation) error {
+		navigation.Loading = isLoading
+		return nil
+	}
+}
+
 // Navigation is a set of navigation entries.
 type Navigation struct {
 	Title      string       `json:"title,omitempty"`
@@ -52,6 +60,7 @@ type Navigation struct {
 	Children   []Navigation `json:"children,omitempty"`
 	IconName   string       `json:"iconName,omitempty"`
 	IconSource string       `json:"iconSource,omitempty"`
+	Loading    bool         `json:"isLoading"`
 }
 
 // New creates a Navigation.
@@ -68,12 +77,14 @@ func New(title, navigationPath string, options ...Option) (*Navigation, error) {
 }
 
 // CRDEntries generates navigation entries for CRDs.
-func CRDEntries(ctx context.Context, prefix, namespace string, objectStore store.Store, wantsClusterScoped bool) ([]Navigation, error) {
+func CRDEntries(ctx context.Context, prefix, namespace string, objectStore store.Store, wantsClusterScoped bool) ([]Navigation, bool, error) {
 	var list []Navigation
 
-	crds, err := CustomResourceDefinitions(ctx, objectStore)
+	loading := false
+
+	crds, _, err := CustomResourceDefinitions(ctx, objectStore)
 	if err != nil {
-		return nil, errors.Wrap(err, "retrieving CRDs")
+		return nil, false, errors.Wrap(err, "retrieving CRDs")
 	}
 
 	sort.Slice(crds, func(i, j int) bool {
@@ -87,33 +98,39 @@ func CRDEntries(ctx context.Context, prefix, namespace string, objectStore store
 			continue
 		}
 
-		objects, err := ListCustomResources(ctx, crds[i], namespace, objectStore, nil)
+		objects, isLoading, err := ListCustomResources(ctx, crds[i], namespace, objectStore, nil)
 		if err != nil {
-			return nil, err
+			return nil, false, err
+		}
+
+		if isLoading {
+			loading = true
 		}
 
 		if len(objects.Items) > 0 {
-			navigation, err := New(crds[i].Name, path.Join(prefix, crds[i].Name), SetNavigationIcon(icon.CustomResourceDefinition))
+			navigation, err := New(crds[i].Name, path.Join(prefix, crds[i].Name),
+				SetNavigationIcon(icon.CustomResourceDefinition),
+				SetLoading(isLoading))
 			if err != nil {
-				return nil, err
+				return nil, false, err
 			}
 
 			list = append(list, *navigation)
 		}
 	}
 
-	return list, nil
+	return list, loading, nil
 }
 
-func CustomResourceDefinitions(ctx context.Context, o store.Store) ([]*apiextv1beta1.CustomResourceDefinition, error) {
+func CustomResourceDefinitions(ctx context.Context, o store.Store) ([]*apiextv1beta1.CustomResourceDefinition, bool, error) {
 	key := store.Key{
 		APIVersion: "apiextensions.k8s.io/v1beta1",
 		Kind:       "CustomResourceDefinition",
 	}
 
-	rawList, err := o.List(ctx, key)
+	rawList, hasSynced, err := o.List(ctx, key)
 	if err != nil {
-		return nil, errors.Wrap(err, "listing CRDs")
+		return nil, false, errors.Wrap(err, "listing CRDs")
 	}
 
 	logger := log.From(ctx)
@@ -125,14 +142,14 @@ func CustomResourceDefinitions(ctx context.Context, o store.Store) ([]*apiextv1b
 		// NOTE: (bryanl) vendored converter can't convert from int64 to float64. Watching
 		// https://github.com/kubernetes-sigs/yaml/pull/14 to see when it gets pulled into
 		// a release so Octant can switch back.
-		if err := octantunstructured.DefaultUnstructuredConverter.FromUnstructured(rawList.Items[i].Object, crd); err != nil {
+		if err := octantUnstructured.DefaultUnstructuredConverter.FromUnstructured(rawList.Items[i].Object, crd); err != nil {
 			logger.Errorf("%v", errors.Wrapf(errors.Wrapf(err, "converting unstructured object to custom resource definition"), rawList.Items[i].GetName()))
 			continue
 		}
 		list = append(list, crd)
 	}
 
-	return list, nil
+	return list, hasSynced, nil
 }
 
 // CustomResourceDefinition retrieves a CRD.
@@ -157,9 +174,9 @@ func ListCustomResources(
 	crd *apiextv1beta1.CustomResourceDefinition,
 	namespace string,
 	o store.Store,
-	selector *labels.Set) (*unstructured.UnstructuredList, error) {
+	selector *labels.Set) (*unstructured.UnstructuredList, bool, error) {
 	if crd == nil {
-		return nil, errors.New("crd is nil")
+		return nil, false, errors.New("crd is nil")
 	}
 	gvk := schema.GroupVersionKind{
 		Group:   crd.Spec.Group,
@@ -179,18 +196,19 @@ func ListCustomResources(
 		key.Namespace = namespace
 	}
 
-	objects, err := o.List(ctx, key)
+	objects, hasSynced, err := o.List(ctx, key)
 	if err != nil {
-		return nil, errors.Wrapf(err, "listing custom resources for %q", crd.Name)
+		return nil, false, errors.Wrapf(err, "listing custom resources for %q", crd.Name)
 	}
 
-	return objects, nil
+	return objects, hasSynced, nil
 }
 
 type navConfig struct {
-	title    string
-	suffix   string
-	iconName string
+	title     string
+	suffix    string
+	iconName  string
+	isLoading bool
 }
 
 // EntriesHelper generates navigation entries.
@@ -199,9 +217,9 @@ type EntriesHelper struct {
 }
 
 // Add adds an entry.
-func (neh *EntriesHelper) Add(title, suffix, iconName string) {
+func (neh *EntriesHelper) Add(title, suffix, iconName string, isLoading bool) {
 	neh.navConfigs = append(neh.navConfigs, navConfig{
-		title: title, suffix: suffix, iconName: iconName,
+		title: title, suffix: suffix, iconName: iconName, isLoading: isLoading,
 	})
 }
 
@@ -210,7 +228,9 @@ func (neh *EntriesHelper) Generate(prefix string) ([]Navigation, error) {
 	var navigations []Navigation
 
 	for _, nc := range neh.navConfigs {
-		navigation, err := New(nc.title, path.Join(prefix, nc.suffix), SetNavigationIcon(nc.iconName))
+		navigation, err := New(nc.title, path.Join(prefix, nc.suffix),
+			SetNavigationIcon(nc.iconName),
+			SetLoading(nc.isLoading))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/navigation/navigation_test.go
+++ b/pkg/navigation/navigation_test.go
@@ -38,7 +38,7 @@ func Test_NewNavigation(t *testing.T) {
 func TestEntriesHelper(t *testing.T) {
 	neh := EntriesHelper{}
 
-	neh.Add("title", "suffix", icon.OverviewService)
+	neh.Add("title", "suffix", icon.OverviewService, false)
 
 	list, err := neh.Generate("/prefix")
 	require.NoError(t, err)
@@ -71,7 +71,7 @@ func TestCRDEntries_namespace_scoped(t *testing.T) {
 	}
 	objectStore.EXPECT().
 		List(gomock.Any(), crdKey).
-		Return(crds, nil).
+		Return(crds, false, nil).
 		AnyTimes()
 
 	clusterCR := createCR("testing", "v1", "ClusterScoped", "cluster-scoped")
@@ -86,7 +86,7 @@ func TestCRDEntries_namespace_scoped(t *testing.T) {
 	}
 	objectStore.EXPECT().
 		List(gomock.Any(), crNamespaceKey).
-		Return(namespaceCRs, nil).
+		Return(namespaceCRs, false, nil).
 		AnyTimes()
 	crClusterKey := store.Key{
 		APIVersion: "testing/v1",
@@ -94,12 +94,12 @@ func TestCRDEntries_namespace_scoped(t *testing.T) {
 	}
 	objectStore.EXPECT().
 		List(gomock.Any(), crClusterKey).
-		Return(clusterCRs, nil).
+		Return(clusterCRs, false, nil).
 		AnyTimes()
 
 	ctx := context.Background()
 
-	namespaceGot, err := CRDEntries(ctx, "/prefix", "default", objectStore, false)
+	namespaceGot, _, err := CRDEntries(ctx, "/prefix", "default", objectStore, false)
 	require.NoError(t, err)
 
 	namespaceExpected := []Navigation{
@@ -108,7 +108,7 @@ func TestCRDEntries_namespace_scoped(t *testing.T) {
 
 	assert.Equal(t, namespaceExpected, namespaceGot)
 
-	clusterGot, err := CRDEntries(ctx, "/prefix", "default", objectStore, true)
+	clusterGot, _, err := CRDEntries(ctx, "/prefix", "default", objectStore, true)
 	require.NoError(t, err)
 
 	clusterExpected := []Navigation{

--- a/pkg/navigation/object.go
+++ b/pkg/navigation/object.go
@@ -1,0 +1,1 @@
+package navigation

--- a/pkg/plugin/api/api_test.go
+++ b/pkg/plugin/api/api_test.go
@@ -68,7 +68,7 @@ func TestAPI(t *testing.T) {
 			name: "list",
 			initFunc: func(t *testing.T, mocks *apiMocks) {
 				mocks.objectStore.EXPECT().
-					List(gomock.Any(), gomock.Eq(listKey)).Return(objects, nil)
+					List(gomock.Any(), gomock.Eq(listKey)).Return(objects, false, nil)
 			},
 			doFunc: func(t *testing.T, client *api.Client) {
 				clientCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)

--- a/pkg/plugin/api/server.go
+++ b/pkg/plugin/api/server.go
@@ -71,7 +71,9 @@ var _ Service = (*GRPCService)(nil)
 
 // List lists objects.
 func (s *GRPCService) List(ctx context.Context, key store.Key) (*unstructured.UnstructuredList, error) {
-	return s.ObjectStore.List(ctx, key)
+	// TODO: support hasSynced
+	list, _, err := s.ObjectStore.List(ctx, key)
+	return list, err
 }
 
 // Get retrieves an object.

--- a/pkg/store/event.go
+++ b/pkg/store/event.go
@@ -1,0 +1,1 @@
+package store

--- a/pkg/view/component/table.go
+++ b/pkg/view/component/table.go
@@ -19,6 +19,7 @@ type TableConfig struct {
 	Columns      []TableCol `json:"columns"`
 	Rows         []TableRow `json:"rows"`
 	EmptyContent string     `json:"emptyContent"`
+	Loading      bool       `json:"loading"`
 }
 
 // TableCol describes a column from a table. Accessor is the key this
@@ -172,4 +173,12 @@ func (t *Table) MarshalJSON() ([]byte, error) {
 
 	m.Metadata.Type = typeTable
 	return json.Marshal(&m)
+}
+
+func (t *Table) SetIsLoading(isLoading bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.Config.Loading = isLoading
+
 }

--- a/pkg/view/component/table.go
+++ b/pkg/view/component/table.go
@@ -61,18 +61,19 @@ type Table struct {
 }
 
 // NewTable creates a table component
-func NewTable(title string, cols []TableCol) *Table {
+func NewTable(title, placeholder string, cols []TableCol) *Table {
 	return &Table{
 		base: newBase(typeTable, TitleFromString(title)),
 		Config: TableConfig{
-			Columns: cols,
+			Columns:      cols,
+			EmptyContent: placeholder,
 		},
 	}
 }
 
 // NewTableWithRows creates a table with rows.
-func NewTableWithRows(title string, cols []TableCol, rows []TableRow) *Table {
-	table := NewTable(title, cols)
+func NewTableWithRows(title, placeholder string, cols []TableCol, rows []TableRow) *Table {
+	table := NewTable(title, placeholder, cols)
 	table.Add(rows...)
 	return table
 }
@@ -96,6 +97,10 @@ func NewTableCols(keys ...string) []TableCol {
 // IsEmpty returns true if there is one or more rows.
 func (t *Table) IsEmpty() bool {
 	return len(t.Config.Rows) < 1
+}
+
+func (t *Table) SetPlaceholder(placeholder string) {
+	t.Config.EmptyContent = placeholder
 }
 
 func (t *Table) Sort(name string, reverse bool) {

--- a/pkg/view/component/table_test.go
+++ b/pkg/view/component/table_test.go
@@ -115,12 +115,12 @@ func Test_Table_isEmpty(t *testing.T) {
 	}{
 		{
 			name:    "empty",
-			table:   NewTable("my table", NewTableCols("col1")),
+			table:   NewTable("my table", "placeholder", NewTableCols("col1")),
 			isEmpty: true,
 		},
 		{
 			name: "not empty",
-			table: NewTableWithRows("my table", NewTableCols("col1"), []TableRow{
+			table: NewTableWithRows("my table", "placeholder", NewTableCols("col1"), []TableRow{
 				{"col1": NewText("cell1")},
 			}),
 			isEmpty: false,
@@ -135,7 +135,7 @@ func Test_Table_isEmpty(t *testing.T) {
 }
 
 func Test_Table_AddColumn(t *testing.T) {
-	table := NewTable("table", NewTableCols("a"))
+	table := NewTable("table", "placeholder", NewTableCols("a"))
 	table.AddColumn("b")
 	expected := NewTableCols("a", "b")
 
@@ -181,9 +181,9 @@ func Test_Table_Sort(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			table := NewTableWithRows("table", NewTableCols("a"), tc.rows)
+			table := NewTableWithRows("table", "placeholder", NewTableCols("a"), tc.rows)
 			table.Sort("a", tc.reverse)
-			expected := NewTableWithRows("table", NewTableCols("a"), tc.expected)
+			expected := NewTableWithRows("table", "placeholder", NewTableCols("a"), tc.expected)
 
 			assert.Equal(t, expected, table)
 		})

--- a/pkg/view/component/table_test.go
+++ b/pkg/view/component/table_test.go
@@ -56,11 +56,11 @@ func Test_Table_Marshal(t *testing.T) {
 				base: newBase(typeTable, TitleFromString("my table")),
 				Config: TableConfig{
 					Columns: []TableCol{
-						TableCol{Name: "Name", Accessor: "Name"},
-						TableCol{Name: "Description", Accessor: "Description"},
+						{Name: "Name", Accessor: "Name"},
+						{Name: "Description", Accessor: "Description"},
 					},
 					Rows: []TableRow{
-						TableRow{
+						{
 							"Name": &Text{
 								Config: TextConfig{
 									Text: "First",
@@ -72,7 +72,7 @@ func Test_Table_Marshal(t *testing.T) {
 								},
 							},
 						},
-						TableRow{
+						{
 							"Name": &Text{
 								Config: TextConfig{
 									Text: "Last",
@@ -86,6 +86,7 @@ func Test_Table_Marshal(t *testing.T) {
 						},
 					},
 					EmptyContent: "",
+					Loading:      false,
 				},
 			},
 			expectedPath: "table.json",
@@ -95,7 +96,7 @@ func Test_Table_Marshal(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			actual, err := json.Marshal(tc.input)
-			isErr := (err != nil)
+			isErr := err != nil
 			if isErr != tc.isErr {
 				t.Fatalf("Unexpected error: %v", err)
 			}

--- a/pkg/view/component/testdata/table.json
+++ b/pkg/view/component/testdata/table.json
@@ -57,6 +57,7 @@
         }
       }
     ],
-    "emptyContent": ""
+    "emptyContent": "",
+    "loading": false
   }
 }

--- a/web/src/app/components/navigation/navigation.component.html
+++ b/web/src/app/components/navigation/navigation.component.html
@@ -1,12 +1,13 @@
 <clr-tree-node
-        class="section"
         *ngFor="let section of navigation.sections; trackBy: identifyNavigationItem"
-        [clrExpanded]="true">
+        [clrExpanded]="true"
+        [clrLoading]="section.isLoading"
+        class="section">
     <a
-            [routerLink]="section.path"
-            routerLinkActive="active"
             [routerLinkActiveOptions]="{exact: true}"
-            class="clr-treenode-link section">
+            [routerLink]="section.path"
+            class="clr-treenode-link section"
+            routerLinkActive="active">
         <span>
         <clr-icon [attr.shape]="section.iconName | default:'home'"></clr-icon>
             {{ section.title }}
@@ -15,12 +16,13 @@
 
     <clr-tree-node
             *ngFor="let category of section.children; trackBy: identifyNavigationItem"
-            [clrExpanded]="true">
+            [clrExpanded]="true"
+            [clrLoading]="category.isLoading">
         <a
-                [routerLink]="category.path"
-                routerLinkActive="active"
                 [routerLinkActiveOptions]="{exact: true}"
-                class="clr-treenode-link category">
+                [routerLink]="category.path"
+                class="clr-treenode-link category"
+                routerLinkActive="active">
       <span>
       <clr-icon [attr.shape]="itemIcon(category) | default:'folder'"></clr-icon>
           {{ category.title }}
@@ -29,11 +31,12 @@
         </a>
 
         <clr-tree-node
-                *ngFor="let entry of category.children; trackBy: identifyNavigationItem">
+                *ngFor="let entry of category.children; trackBy: identifyNavigationItem"
+                [clrLoading]="entry.isLoading">
             <a
                     [routerLink]="entry.path"
-                    routerLinkActive="active"
-                    class="clr-treenode-link item">
+                    class="clr-treenode-link item"
+                    routerLinkActive="active">
                 <clr-icon [attr.shape]="itemIcon(entry) | default:'folder'"></clr-icon>
                 <span>
                     {{ entry.title }}

--- a/web/src/app/components/navigation/navigation.component.ts
+++ b/web/src/app/components/navigation/navigation.component.ts
@@ -30,7 +30,7 @@ export class NavigationComponent {
     private iconService: IconService,
     private contentStreamService: ContentStreamService
   ) {
-    let streamer: Streamer = {
+    const streamer: Streamer = {
       behavior: this.behavior,
       handler: this.handleEvent,
     };

--- a/web/src/app/models/content.ts
+++ b/web/src/app/models/content.ts
@@ -221,6 +221,7 @@ export interface TableView extends View {
     columns: TableColumn[];
     rows: TableRow[];
     emptyContent: string;
+    loading: boolean;
   };
 }
 

--- a/web/src/app/models/navigation.ts
+++ b/web/src/app/models/navigation.ts
@@ -7,6 +7,7 @@ export interface NavigationChild {
   children?: NavigationChild[];
   iconName: string;
   iconSource: string;
+  isLoading: boolean;
 }
 
 export interface Navigation {

--- a/web/src/app/modules/overview/components/datagrid/datagrid.component.html
+++ b/web/src/app/modules/overview/components/datagrid/datagrid.component.html
@@ -16,6 +16,12 @@
                     {{pagination.firstItem + 1}} - {{pagination.lastItem + 1}}
                     of {{pagination.totalItems}} items
                 </clr-dg-pagination>
+
+                <ng-container *ngIf="loading">
+                    <span class="spinner spinner-inline" style="margin-right: 10px">
+                        Loading...
+                    </span>
+                </ng-container>
             </clr-dg-footer>
         </clr-datagrid>
     </div>

--- a/web/src/app/modules/overview/components/datagrid/datagrid.component.ts
+++ b/web/src/app/modules/overview/components/datagrid/datagrid.component.ts
@@ -24,6 +24,7 @@ export class DatagridComponent implements OnChanges {
 
   identifyRow = trackByIndex;
   identifyColumn = trackByIdentity;
+  loading: boolean;
 
   constructor(private viewService: ViewService) {}
 
@@ -36,6 +37,7 @@ export class DatagridComponent implements OnChanges {
       this.rows = current.config.rows;
       this.placeholder = current.config.emptyContent;
       this.lastUpdated = new Date();
+      this.loading = current.config.loading;
     }
   }
 }


### PR DESCRIPTION
* how loading indicators when informer cache has not synced
* use less allocations when transversing sections for content
* add placeholders for component tables

note: this doesn't solve the slow loading of views in the web viewer. We'll have to solve that another way.

#119 