### PR TITLE
Fix scroll issue in Logs Container & added unit test for it

### DIFF
--- a/changelogs/unreleased/162-nfarruggiagl
+++ b/changelogs/unreleased/162-nfarruggiagl
@@ -1,0 +1,1 @@
+Fix scroll issue in Logs Container & added unit test for it

--- a/web/src/app/modules/overview/components/logs/logs.component.spec.ts
+++ b/web/src/app/modules/overview/components/logs/logs.component.spec.ts
@@ -4,6 +4,24 @@
 
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { LogsComponent } from './logs.component';
+import { LogEntry } from 'src/app/models/content';
+
+/**
+ * Adds 15 logs to the provided list.
+ * @param currentLogList Current list of logs when this function is called.
+ * @returns New list of logs.
+ */
+const addLogsToList = (currentLogList: LogEntry[]): LogEntry[] => {
+  const logList = [...currentLogList];
+  for(let i = 1; i <= 15; i++) {
+    logList.push({
+      timestamp: '2019-08-19T12:07:00.1222053Z',
+      message: 'Just for test'
+    })
+  }
+
+  return logList;
+}
 
 describe('LogsComponent', () => {
   let component: LogsComponent;
@@ -23,5 +41,20 @@ describe('LogsComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should stay at the bottom of the container when new logs arrive', () => {
+    const { nativeElement } = component.scrollTarget;
+    component.scrollToBottom = true;
+
+    component.containerLogs = addLogsToList([]);
+    fixture.detectChanges();
+    expect(component.containerLogs.length).toBe(15);
+    expect(nativeElement.scrollTop).toEqual(nativeElement.scrollHeight - nativeElement.offsetHeight);
+
+    component.containerLogs = addLogsToList(component.containerLogs)
+    fixture.detectChanges();
+    expect(component.containerLogs.length).toBe(30);
+    expect(nativeElement.scrollTop).toEqual(nativeElement.scrollHeight - nativeElement.offsetHeight);
   });
 });

--- a/web/src/app/modules/overview/components/logs/logs.component.ts
+++ b/web/src/app/modules/overview/components/logs/logs.component.ts
@@ -10,6 +10,8 @@ import {
   OnDestroy,
   OnInit,
   ViewChild,
+  IterableDiffers,
+  IterableDiffer
 } from '@angular/core';
 import { LogsView, LogEntry } from 'src/app/models/content';
 import {
@@ -24,8 +26,9 @@ import {
 })
 export class LogsComponent implements OnInit, OnDestroy, AfterViewChecked {
   private logStream: PodLogsStreamer;
-  private scrollToBottom = false;
-
+  scrollToBottom = false;
+  
+  private containerLogsDiffer: IterableDiffer<LogEntry>;
   @Input() view: LogsView;
   @ViewChild('scrollTarget') scrollTarget: ElementRef;
   containerLogs: LogEntry[] = [];
@@ -33,9 +36,13 @@ export class LogsComponent implements OnInit, OnDestroy, AfterViewChecked {
   selectedContainer = '';
   shouldDisplayTimestamp = true;
 
-  constructor(private podLogsService: PodLogsService) {}
+  constructor(
+    private podLogsService: PodLogsService,
+    private iterableDiffers: IterableDiffers
+  ) {}
 
   ngOnInit() {
+    this.containerLogsDiffer = this.iterableDiffers.find(this.containerLogs).create();
     if (this.view) {
       if (
         this.view.config.containers &&
@@ -99,7 +106,8 @@ export class LogsComponent implements OnInit, OnDestroy, AfterViewChecked {
   }
 
   ngAfterViewChecked() {
-    if (this.scrollToBottom) {
+    const change = this.containerLogsDiffer.diff(this.containerLogs);
+    if (change && this.scrollToBottom) {
       const { nativeElement } = this.scrollTarget;
       nativeElement.scrollTop = nativeElement.scrollHeight;
     }


### PR DESCRIPTION
Fix to address #162 

- LogsComponent: the component will now check for changes in `containerLogs` so it knows when a new log is added. 

If the user is not at the bottom of the list, the item will be added to the bottom of it but the scroll position will not change. 
If the user is at the bottom of the list, and a new item is added, the scroll position will remain at the bottom so the user will see all the latests items.
The user should be able to scroll whenever is needed.

- Unit Test added for this functionality.