### PR TITLE
Show succeeded pods under job view only

### DIFF
--- a/changelogs/190-GuessWhoSamFoo
+++ b/changelogs/190-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Added pods with succeeded phase to be listed under job viewer.


### PR DESCRIPTION
#63 

Pushing code for this early because it requires input. Is it correct to implicitly have pods available in another view? Perhaps this should be configurable across all views

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>