### PR TITLE
Set accepted hosts as an optional env variable

### DIFF
--- a/changelogs/unreleased/194-aksalj
+++ b/changelogs/unreleased/194-aksalj
@@ -1,0 +1,1 @@
+Set accepted hosts as an optional env variable

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,6 +7,7 @@ Octant is configurable through environment variables defined at runtime.
 * `KUBECONFIG` - set to non-empty location if you want to set KUBECONFIG with an environment variable.
 * `OCTANT_DISABLE_OPEN_BROWSER` - set to a non-empty value if you don't the browser launched when the dashboard start up.
 * `OCTANT_LISTENER_ADDR` - set to address you want dashboard service to start on. (e.g. `localhost:8080`)
+* `OCTANT_ACCEPTED_HOSTS` - set to comma-separated string of hosts to be accepted. (e.g. `demo.octant.example.com,awesome.octant.zr`)
 * `OCTANT_VERBOSE_CACHE` - set to a non-empty value to view cache actions
 * `OCTANT_LOCAL_CONTENT` - set to a directory and dash will serve content responses from here. An example directory lives in `examples/content`
 * `OCTANT_PLUGIN_PATH` - add a plugin directory or multiple directories separated by `:`. Plugins will load by default from `$HOME/.config/octant/plugins`

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
@@ -30,6 +31,7 @@ import (
 const (
 	// ListenerAddrKey is the environment variable for the Octant listener address.
 	ListenerAddrKey = "OCTANT_LISTENER_ADDR"
+	AcceptedHostsKey = "OCTANT_ACCEPTED_HOSTS"
 	// PathPrefix is a string for the api path prefix.
 	PathPrefix          = "/api/v1"
 	defaultListenerAddr = "127.0.0.1:7777"
@@ -40,6 +42,11 @@ func acceptedHosts() []string {
 		"localhost",
 		"127.0.0.1",
 	}
+	if customHosts := os.Getenv(AcceptedHostsKey); customHosts != "" {
+		allowedHosts := strings.Split(customHosts, ",")
+		hosts = append(hosts, allowedHosts...)
+	}
+	
 	listenerAddr := ListenerAddr()
 	host, _, err := net.SplitHostPort(listenerAddr)
 	if err != nil {


### PR DESCRIPTION
Pass accepted hosts in an env variable to avoid 403 errors on deployments accessible on hostnames other than `localhost` and `"127.0.0.1"`