### PR TITLE
Adds three new resource examples

### DIFF
--- a/examples/resources/config-map.yaml
+++ b/examples/resources/config-map.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-config
+  namespace: default
+data:
+  app.config: |
+    {
+      "app_Name": "example app",
+      "users": [
+        "user1",
+        "user2"
+      ]
+    }

--- a/examples/resources/generic-secret.yaml
+++ b/examples/resources/generic-secret.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: example-secret
+type: generic
+data:
+  API_KEY: bm90aGluZ3Rvc2VlaGVyZQ==

--- a/examples/resources/ingress.yaml
+++ b/examples/resources/ingress.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: example-host-ingress
+spec:
+  rules:
+  - host: www.mycompany.com
+    http:
+      paths:
+      - backend:
+          serviceName: www-service
+          servicePort: 80
+  - host: shop.mycompany.com
+    http:
+      paths:
+      - backend:
+          serviceName: shop-service
+          servicePort: 80


### PR DESCRIPTION
This PR adds the following new resource examples:

* Config map
* Generic Secret
* Basic multi host ingress

It looks like role and rolebinding have already been created so they can be checked off the list from op.

