### PR TITLE
Allow pods to be deleted

### DIFF
--- a/changelogs/unreleased/227-bryanl
+++ b/changelogs/unreleased/227-bryanl
@@ -1,0 +1,1 @@
+Add support for deleting pods

--- a/internal/describer/object.go
+++ b/internal/describer/object.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	"github.com/vmware/octant/internal/api"
 	"github.com/vmware/octant/internal/log"
 	"github.com/vmware/octant/internal/modules/overview/logviewer"
 	"github.com/vmware/octant/internal/modules/overview/resourceviewer"
@@ -81,7 +82,7 @@ func (d *Object) Describe(ctx context.Context, prefix, namespace string, options
 
 	object, err := options.LoadObject(ctx, namespace, options.Fields, d.objectStoreKey)
 	if err != nil {
-		return EmptyContentResponse, errors.Wrapf(err, "loading object with %s", d.objectStoreKey.String())
+		return EmptyContentResponse, api.NewNotFoundError(d.path)
 	} else if object == nil {
 		return EmptyContentResponse, errors.Errorf("unable to load object %s", d.objectStoreKey)
 	}

--- a/internal/event/generator.go
+++ b/internal/event/generator.go
@@ -132,7 +132,7 @@ func handleNotFound(logger log.Logger, contentPath string, requestPath string, i
 	logger.With(
 		"path", contentPath,
 		"requestPath", requestPath,
-	).Errorf("content not found")
+	).Infof("content not found")
 	isRunning = false
 	ch <- octant.Event{
 		Type: octant.EventTypeObjectNotFound,

--- a/internal/modules/configuration/configuration.go
+++ b/internal/modules/configuration/configuration.go
@@ -20,6 +20,7 @@ import (
 	"github.com/vmware/octant/internal/log"
 	"github.com/vmware/octant/internal/module"
 	"github.com/vmware/octant/internal/octant"
+	"github.com/vmware/octant/pkg/action"
 	"github.com/vmware/octant/pkg/icon"
 	"github.com/vmware/octant/pkg/navigation"
 	"github.com/vmware/octant/pkg/view/component"
@@ -38,6 +39,7 @@ type Configuration struct {
 }
 
 var _ module.Module = (*Configuration)(nil)
+var _ module.ActionReceiver = (*Configuration)(nil)
 
 func New(ctx context.Context, options Options) *Configuration {
 	pm := describer.NewPathMatcher("configuration")
@@ -150,5 +152,13 @@ func (c Configuration) RemoveCRD(ctx context.Context, crd *unstructured.Unstruct
 func (c Configuration) Generators() []octant.Generator {
 	return []octant.Generator{
 		c.kubeContextGenerator,
+	}
+}
+
+func (c *Configuration) ActionPaths() map[string]action.DispatcherFunc {
+	objectDeleter := NewObjectDeleter(c.DashConfig.Logger(), c.DashConfig.ObjectStore())
+
+	return map[string]action.DispatcherFunc{
+		objectDeleter.ActionName(): objectDeleter.Handle,
 	}
 }

--- a/internal/modules/configuration/delete_object.go
+++ b/internal/modules/configuration/delete_object.go
@@ -1,0 +1,37 @@
+package configuration
+
+import (
+	"context"
+
+	"github.com/vmware/octant/internal/log"
+	"github.com/vmware/octant/internal/octant"
+	"github.com/vmware/octant/pkg/action"
+	"github.com/vmware/octant/pkg/store"
+)
+
+type ObjectDeleter struct {
+	logger log.Logger
+	store  store.Store
+}
+
+func NewObjectDeleter(logger log.Logger, clusterClient store.Store) *ObjectDeleter {
+	return &ObjectDeleter{
+		logger: logger.With("action", octant.ActionDeleteObject),
+		store:  clusterClient,
+	}
+}
+
+func (d *ObjectDeleter) ActionName() string {
+	return octant.ActionDeleteObject
+}
+
+func (d *ObjectDeleter) Handle(ctx context.Context, payload action.Payload) error {
+	d.logger.With("payload", payload).Debugf("deleting object")
+
+	key, err := store.KeyFromPayload(payload)
+	if err != nil {
+		return err
+	}
+
+	return d.store.Delete(ctx, key)
+}

--- a/internal/modules/configuration/delete_object_test.go
+++ b/internal/modules/configuration/delete_object_test.go
@@ -1,0 +1,51 @@
+package configuration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vmware/octant/internal/log"
+	"github.com/vmware/octant/internal/octant"
+	"github.com/vmware/octant/internal/testutil"
+	"github.com/vmware/octant/pkg/store"
+	"github.com/vmware/octant/pkg/store/fake"
+)
+
+func TestObjectDeleter_ActionName(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	objectStore := fake.NewMockStore(controller)
+
+	logger := log.NopLogger()
+
+	d := NewObjectDeleter(logger, objectStore)
+	require.Equal(t, octant.ActionDeleteObject, d.ActionName())
+}
+
+func TestObjectDeleter_Handle(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	objectStore := fake.NewMockStore(controller)
+
+	pod := testutil.CreatePod("pod")
+	key, err := store.KeyFromObject(pod)
+	require.NoError(t, err)
+
+	objectStore.EXPECT().
+		Delete(gomock.Any(), key).
+		Return(nil)
+
+	logger := log.NopLogger()
+
+	d := NewObjectDeleter(logger, objectStore)
+
+	ctx := context.Background()
+
+	err = d.Handle(ctx, key.ToActionPayload())
+	require.NoError(t, err)
+}

--- a/internal/modules/overview/printer/event_test.go
+++ b/internal/modules/overview/printer/event_test.go
@@ -295,7 +295,7 @@ func Test_EventHandler(t *testing.T) {
 		},
 	}...)
 
-	assert.Equal(t, expected, got)
+	component.AssertEqual(t, expected, got)
 }
 
 func Test_eventsForObject(t *testing.T) {

--- a/internal/modules/overview/printer/object.go
+++ b/internal/modules/overview/printer/object.go
@@ -13,9 +13,17 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/vmware/octant/pkg/action"
 	"github.com/vmware/octant/pkg/view/component"
 	"github.com/vmware/octant/pkg/view/flexlayout"
 )
+
+//go:generate mockgen -source=object.go -destination=./fake/mock_object_interface.go -package=fake github.com/vmware/octant/internal/modules/overview/printer ObjectInterface
+
+// ObjectInterface is an interface for printing an object.
+type ObjectInterface interface {
+	AddButton(name string, payload action.Payload, buttonOptions ...component.ButtonOption)
+}
 
 func defaultMetadataGen(object runtime.Object, fl *flexlayout.FlexLayout, options Options) error {
 	metadata, err := NewMetadata(object, options.Link)
@@ -253,4 +261,8 @@ func (o *Object) ToComponent(ctx context.Context, options Options) (component.Co
 	}
 
 	return o.flexLayout.ToComponent("Summary"), nil
+}
+
+func (o *Object) AddButton(name string, payload action.Payload, buttonOptions ...component.ButtonOption) {
+	o.flexLayout.AddButton(name, payload, buttonOptions...)
 }

--- a/internal/modules/overview/printer/pod_test.go
+++ b/internal/modules/overview/printer/pod_test.go
@@ -18,7 +18,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/vmware/octant/internal/conversion"
+	"github.com/vmware/octant/internal/modules/overview/printer/fake"
+	"github.com/vmware/octant/internal/octant"
 	"github.com/vmware/octant/internal/testutil"
+	"github.com/vmware/octant/pkg/store"
 	"github.com/vmware/octant/pkg/view/component"
 )
 
@@ -408,4 +411,39 @@ func Test_printPodResources(t *testing.T) {
 	})
 
 	assert.Equal(t, expected, got)
+}
+
+func Test_setupPodActions(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	objectInterface := fake.NewMockObjectInterface(controller)
+
+	pod := testutil.CreatePod("pod")
+	key, err := store.KeyFromObject(pod)
+	require.NoError(t, err)
+	payload := key.ToActionPayload()
+	payload["action"] = octant.ActionDeleteObject
+	objectInterface.EXPECT().
+		AddButton("Delete", payload, gomock.Any())
+
+	err = setupPodActions(pod, objectInterface)
+	require.NoError(t, err)
+}
+
+func Test_deletePodConfirmation(t *testing.T) {
+	pod := testutil.CreatePod("pod")
+	option := deletePodConfirmation(pod)
+
+	button := component.Button{}
+	option(&button)
+
+	expected := component.Button{
+		Confirmation: &component.Confirmation{
+			Title: "Delete pod",
+			Body:  "Are you sure you want to delete pod **pod**? This action is permanent and cannot be recovered.",
+		},
+	}
+
+	assert.Equal(t, expected, button)
 }

--- a/internal/octant/actions.go
+++ b/internal/octant/actions.go
@@ -1,0 +1,5 @@
+package octant
+
+const (
+	ActionDeleteObject = "octant/deleteObject"
+)

--- a/pkg/action/payload.go
+++ b/pkg/action/payload.go
@@ -15,6 +15,19 @@ import (
 // Payload is an action payload.
 type Payload map[string]interface{}
 
+// CreatePayload creates a payload with an action name and fields.
+func CreatePayload(actionName string, fields map[string]interface{}) Payload {
+	payload := Payload{
+		"action": actionName,
+	}
+
+	for k, v := range fields {
+		payload[k] = v
+	}
+
+	return payload
+}
+
 // GroupVersionKind extracts a GroupVersionKind from a payload.
 func (p Payload) GroupVersionKind() (schema.GroupVersionKind, error) {
 	group, err := p.String("group")

--- a/pkg/action/payload_test.go
+++ b/pkg/action/payload_test.go
@@ -13,6 +13,20 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+func TestCreatePayload(t *testing.T) {
+	action := "action"
+
+	fields := map[string]interface{}{"foo": "bar"}
+	got := CreatePayload(action, fields)
+
+	expected := Payload{
+		"action": action,
+		"foo":    "bar",
+	}
+
+	assert.Equal(t, expected, got)
+}
+
 func TestPayload_GroupVersionKind(t *testing.T) {
 	payload := Payload{
 		"group":   "group",

--- a/pkg/plugin/grpc_test.go
+++ b/pkg/plugin/grpc_test.go
@@ -267,7 +267,7 @@ func Test_GRPCClient_PrintTab(t *testing.T) {
 			},
 		}
 
-		assert.Equal(t, expected, got)
+		testutil.AssertJSONEqual(t, expected, got)
 	})
 }
 

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -1,0 +1,84 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vmware/octant/internal/gvk"
+	"github.com/vmware/octant/internal/testutil"
+	"github.com/vmware/octant/pkg/action"
+)
+
+func TestKey_ToActionPayload(t *testing.T) {
+	pod := testutil.CreatePod("pod")
+	key := Key{
+		Namespace:  pod.Namespace,
+		APIVersion: pod.APIVersion,
+		Kind:       pod.Kind,
+		Name:       pod.Name,
+	}
+
+	got := key.ToActionPayload()
+
+	expected := action.Payload{
+		"namespace":  pod.Namespace,
+		"apiVersion": pod.APIVersion,
+		"kind":       pod.Kind,
+		"name":       pod.Name,
+	}
+
+	assert.Equal(t, expected, got)
+}
+
+func TestKey_GroupVersionKind(t *testing.T) {
+	pod := testutil.CreatePod("pod")
+	key := Key{
+		Namespace:  pod.Namespace,
+		APIVersion: pod.APIVersion,
+		Kind:       pod.Kind,
+		Name:       pod.Name,
+	}
+
+	got := key.GroupVersionKind()
+	assert.Equal(t, gvk.Pod, got)
+}
+
+func TestKeyFromObject(t *testing.T) {
+	pod := testutil.CreatePod("pod")
+
+	got, err := KeyFromObject(pod)
+	require.NoError(t, err)
+
+	expected := Key{
+		Namespace:  pod.Namespace,
+		APIVersion: pod.APIVersion,
+		Kind:       pod.Kind,
+		Name:       pod.Name,
+	}
+
+	assert.Equal(t, expected, got)
+}
+
+func TestKeyFromPayload(t *testing.T) {
+	pod := testutil.CreatePod("pod")
+
+	payload := action.Payload{
+		"namespace":  pod.Namespace,
+		"apiVersion": pod.APIVersion,
+		"kind":       pod.Kind,
+		"name":       pod.Name,
+	}
+
+	got, err := KeyFromPayload(payload)
+	require.NoError(t, err)
+
+	expected := Key{
+		Namespace:  pod.Namespace,
+		APIVersion: pod.APIVersion,
+		Kind:       pod.Kind,
+		Name:       pod.Name,
+	}
+	assert.Equal(t, expected, got)
+}

--- a/pkg/view/component/alert.go
+++ b/pkg/view/component/alert.go
@@ -18,3 +18,11 @@ type Alert struct {
 	Type    AlertType `json:"type"`
 	Message string    `json:"message"`
 }
+
+// NewAlert creates an instance of Alert.
+func NewAlert(alertType AlertType, message string) Alert {
+	return Alert{
+		Type:    alertType,
+		Message: message,
+	}
+}

--- a/pkg/view/component/alert_test.go
+++ b/pkg/view/component/alert_test.go
@@ -1,0 +1,17 @@
+package component
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAlert(t *testing.T) {
+	got := NewAlert(AlertTypeSuccess, "message")
+	expected := Alert{
+		Type:    AlertTypeSuccess,
+		Message: "message",
+	}
+
+	assert.Equal(t, got, expected)
+}

--- a/pkg/view/component/base.go
+++ b/pkg/view/component/base.go
@@ -7,6 +7,7 @@ package component
 
 const (
 	typeAnnotations        = "annotations"
+	typeButtonGroup        = "buttonGroup"
 	typeCard               = "card"
 	typeCardList           = "cardList"
 	typeContainers         = "containers"

--- a/pkg/view/component/button.go
+++ b/pkg/view/component/button.go
@@ -1,0 +1,82 @@
+package component
+
+import (
+	"encoding/json"
+
+	"github.com/vmware/octant/pkg/action"
+)
+
+// Confirmation is configuration for a confirmation dialog.
+type Confirmation struct {
+	Title string `json:"title"`
+	Body  string `json:"body"`
+}
+
+// ButtonOption is a function for configuring a Button.
+type ButtonOption func(button *Button)
+
+// WithButtonConfirmation configured a button with a confirmation.
+func WithButtonConfirmation(title, body string) ButtonOption {
+	return func(button *Button) {
+		confirmation := Confirmation{
+			Title: title,
+			Body:  body,
+		}
+
+		button.Confirmation = &confirmation
+	}
+}
+
+// Button is a button in a group.
+type Button struct {
+	Name         string         `json:"name"`
+	Payload      action.Payload `json:"payload"`
+	Confirmation *Confirmation  `json:"confirmation,omitempty"`
+}
+
+// NewButton creates an instance of Button.
+func NewButton(name string, payload action.Payload, options ...ButtonOption) Button {
+	button := Button{
+		Name:    name,
+		Payload: payload,
+	}
+
+	for _, option := range options {
+		option(&button)
+	}
+
+	return button
+}
+
+// ButtonGroupConfig is configuration for a button group.
+type ButtonGroupConfig struct {
+	// Buttons are buttons in the group.
+	Buttons []Button `json:"buttons"`
+}
+
+// ButtonGroup is a group of buttons.
+type ButtonGroup struct {
+	base
+	Config ButtonGroupConfig `json:"config"`
+}
+
+// NewButtonGroup creates an instance of ButtonGroup.
+func NewButtonGroup() *ButtonGroup {
+	return &ButtonGroup{
+		base: newBase(typeButtonGroup, nil),
+	}
+}
+
+// AddButton adds a button to the ButtonGroup.
+func (bg *ButtonGroup) AddButton(button Button) {
+	bg.Config.Buttons = append(bg.Config.Buttons, button)
+}
+
+type buttonGroupMarshal ButtonGroup
+
+// MarshalJSON marshals a button group.
+func (bg *ButtonGroup) MarshalJSON() ([]byte, error) {
+	m := buttonGroupMarshal(*bg)
+	m.Metadata.Type = typeButtonGroup
+	return json.Marshal(&m)
+}

--- a/pkg/view/component/button_test.go
+++ b/pkg/view/component/button_test.go
@@ -1,0 +1,45 @@
+package component
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ButtonGroup_Marshal(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        func() *ButtonGroup
+		expectedFile string
+		isErr        bool
+	}{
+		{
+			name: "empty button group",
+			input: func() *ButtonGroup {
+				return NewButtonGroup()
+			},
+			expectedFile: "button_group_empty.json",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := json.Marshal(test.input())
+			if test.isErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			expected, err := ioutil.ReadFile(filepath.Join("testdata", test.expectedFile))
+			require.NoError(t, err)
+
+			assert.JSONEq(t, string(expected), string(got))
+
+		})
+	}
+}

--- a/pkg/view/component/flexlayout.go
+++ b/pkg/view/component/flexlayout.go
@@ -47,7 +47,8 @@ type FlexLayoutSection []FlexLayoutItem
 
 // FlexLayoutConfig is configuration for the flex layout view.
 type FlexLayoutConfig struct {
-	Sections []FlexLayoutSection `json:"sections,omitempty"`
+	Sections    []FlexLayoutSection `json:"sections,omitempty"`
+	ButtonGroup *ButtonGroup        `json:"buttonGroup,omitempty"`
 }
 
 // FlexLayout is a flex layout view.
@@ -60,6 +61,9 @@ type FlexLayout struct {
 func NewFlexLayout(title string) *FlexLayout {
 	return &FlexLayout{
 		base: newBase(typeFlexLayout, TitleFromString(title)),
+		Config: FlexLayoutConfig{
+			ButtonGroup: NewButtonGroup(),
+		},
 	}
 }
 
@@ -80,6 +84,10 @@ func (fl *FlexLayout) MarshalJSON() ([]byte, error) {
 	x := flexLayoutMarshal(*fl)
 	x.Metadata.Type = typeFlexLayout
 	return json.Marshal(&x)
+}
+
+func (fl *FlexLayout) SetButtonGroup(group *ButtonGroup) {
+	fl.Config.ButtonGroup = group
 }
 
 // Tab represents a tab. A tab is a flex layout with a name.

--- a/pkg/view/component/summary.go
+++ b/pkg/view/component/summary.go
@@ -11,6 +11,7 @@ import "encoding/json"
 type SummaryConfig struct {
 	Sections []SummarySection `json:"sections"`
 	Actions  []Action         `json:"actions,omitempty"`
+	Alert    *Alert           `json:"alert,omitempty"`
 }
 
 // SummarySection is a section within a summary
@@ -86,6 +87,11 @@ func (t *Summary) AddAction(action Action) {
 // Add adds additional items to the tail of the summary.
 func (t *Summary) Add(sections ...SummarySection) {
 	t.Config.Sections = append(t.Config.Sections, sections...)
+}
+
+// SetAlert sets an alert for the summary.
+func (t *Summary) SetAlert(alert Alert) {
+	t.Config.Alert = &alert
 }
 
 // Sections returns sections for the summary.

--- a/pkg/view/component/summary_test.go
+++ b/pkg/view/component/summary_test.go
@@ -27,6 +27,10 @@ func Test_Summary_Marshal(t *testing.T) {
 			input: &Summary{
 				base: newBase(typeSummary, TitleFromString("my summary")),
 				Config: SummaryConfig{
+					Alert: &Alert{
+						Type:    AlertTypeInfo,
+						Message: "info",
+					},
 					Sections: []SummarySection{
 						{
 							Header: "Containers",

--- a/pkg/view/component/testdata/button_group_empty.json
+++ b/pkg/view/component/testdata/button_group_empty.json
@@ -1,0 +1,8 @@
+{
+  "metadata": {
+    "type": "buttonGroup"
+  },
+  "config": {
+    "buttons": null
+  }
+}

--- a/pkg/view/component/testdata/summary.json
+++ b/pkg/view/component/testdata/summary.json
@@ -9,6 +9,10 @@
     ]
   },
   "config": {
+    "alert": {
+      "message": "info",
+      "type": "info"
+    },
     "sections": [
       {
         "header": "Containers",

--- a/pkg/view/flexlayout/flexlayout.go
+++ b/pkg/view/flexlayout/flexlayout.go
@@ -6,24 +6,34 @@ SPDX-License-Identifier: Apache-2.0
 package flexlayout
 
 import (
+	"github.com/vmware/octant/pkg/action"
 	"github.com/vmware/octant/pkg/view/component"
 )
 
 // FlexLayout is a flex layout manager.
 type FlexLayout struct {
-	sections []*Section
+	sections    []*Section
+	buttonGroup *component.ButtonGroup
 }
 
 // New creates an instance of FlexLayout.
 func New() *FlexLayout {
-	return &FlexLayout{}
+	return &FlexLayout{
+		buttonGroup: component.NewButtonGroup(),
+	}
 }
 
-// AddSection adds a new section to the grid layout.
+// AddSection adds a new section to the flex layout.
 func (fl *FlexLayout) AddSection() *Section {
 	section := NewSection()
 	fl.sections = append(fl.sections, section)
 	return section
+}
+
+// AddButton adds a button the button group for a flex layout.
+func (fl *FlexLayout) AddButton(name string, payload action.Payload, buttonOptions ...component.ButtonOption) {
+	button := component.NewButton(name, payload, buttonOptions...)
+	fl.buttonGroup.AddButton(button)
 }
 
 // ToComponent converts the FlexLayout to a FlexLayout.
@@ -51,6 +61,7 @@ func (fl *FlexLayout) ToComponent(title string) *component.FlexLayout {
 
 	view := component.NewFlexLayout(title)
 	view.AddSections(sections...)
+	view.SetButtonGroup(fl.buttonGroup)
 
 	return view
 }

--- a/pkg/view/flexlayout/flexlayout_test.go
+++ b/pkg/view/flexlayout/flexlayout_test.go
@@ -8,10 +8,10 @@ package flexlayout_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/octant/pkg/action"
 	"github.com/vmware/octant/pkg/view/component"
 	"github.com/vmware/octant/pkg/view/flexlayout"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestFlexLayout(t *testing.T) {
@@ -23,35 +23,34 @@ func TestFlexLayout(t *testing.T) {
 	t2 := component.NewText("item 2")
 	t3 := component.NewText("item 3")
 
-	require.NoError(t, section1.Add(t1, 12))
-	require.NoError(t, section1.Add(t2, 12))
-	require.NoError(t, section1.Add(t3, 12))
+	require.NoError(t, section1.Add(t1, component.WidthFull))
+	require.NoError(t, section1.Add(t2, component.WidthFull))
+	require.NoError(t, section1.Add(t3, component.WidthFull))
 
 	section2 := fl.AddSection()
 
 	t4 := component.NewText("item 4")
 	t5 := component.NewText("item 4")
 
-	require.NoError(t, section2.Add(t4, 6))
-	require.NoError(t, section2.Add(t5, 6))
+	require.NoError(t, section2.Add(t4, component.WidthHalf))
+	require.NoError(t, section2.Add(t5, component.WidthHalf))
 
 	got := fl.ToComponent("Title")
-
 
 	expected := component.NewFlexLayout("Title")
 	expected.AddSections([]component.FlexLayoutSection{
 		{
-			component.FlexLayoutItem{Width: 12, View: t1},
-			component.FlexLayoutItem{Width: 12, View: t2},
-			component.FlexLayoutItem{Width: 12, View: t3},
+			component.FlexLayoutItem{Width: component.WidthFull, View: t1},
+			component.FlexLayoutItem{Width: component.WidthFull, View: t2},
+			component.FlexLayoutItem{Width: component.WidthFull, View: t3},
 		},
 		{
-			component.FlexLayoutItem{Width: 6, View: t4},
-			component.FlexLayoutItem{Width: 6, View: t5},
+			component.FlexLayoutItem{Width: component.WidthHalf, View: t4},
+			component.FlexLayoutItem{Width: component.WidthHalf, View: t5},
 		},
 	}...)
 
-	assert.Equal(t, expected, got)
+	component.AssertEqual(t, expected, got)
 }
 
 func TestFlexLayout_default_title(t *testing.T) {
@@ -60,5 +59,18 @@ func TestFlexLayout_default_title(t *testing.T) {
 	got := fl.ToComponent("")
 	expected := component.NewFlexLayout("Summary")
 
-	assert.Equal(t, expected, got)
+	component.AssertEqual(t, expected, got)
+}
+
+func TestFlexLayout_add_button(t *testing.T) {
+	fl := flexlayout.New()
+	fl.AddButton("button", action.Payload{})
+
+	got := fl.ToComponent("Title")
+	expected := component.NewFlexLayout("Title")
+	buttonGroup := component.NewButtonGroup()
+	buttonGroup.AddButton(component.NewButton("button", action.Payload{}))
+	expected.SetButtonGroup(buttonGroup)
+
+	component.AssertEqual(t, expected, got)
 }

--- a/web/src/app/models/content.ts
+++ b/web/src/app/models/content.ts
@@ -69,9 +69,27 @@ export interface FlexLayoutItem {
   view: View;
 }
 
+export interface Confirmation {
+  title: string;
+  body: string;
+}
+
+export interface Button {
+  payload: {};
+  name: string;
+  confirmation?: Confirmation;
+}
+
+export interface ButtonGroupView extends View {
+  config: {
+    buttons: Button[];
+  };
+}
+
 export interface FlexLayoutView extends View {
   config: {
     sections: FlexLayoutItem[][];
+    buttonGroup: ButtonGroupView;
   };
 }
 
@@ -213,6 +231,7 @@ export interface SummaryView extends View {
   config: {
     sections: SummaryItem[];
     actions: Action[];
+    alert?: Alert;
   };
 }
 

--- a/web/src/app/modules/overview/components/alert/alert.component.html
+++ b/web/src/app/modules/overview/components/alert/alert.component.html
@@ -1,0 +1,10 @@
+<div [ngClass]="['alert', alertClass]" role="alert">
+    <div class="alert-items">
+        <div class="alert-item static">
+            <div class="alert-icon-wrapper">
+                <clr-icon [attr.shape]="shape" class="alert-icon"></clr-icon>
+            </div>
+            <span class="alert-text">{{message}}</span>
+        </div>
+    </div>
+</div>

--- a/web/src/app/modules/overview/components/alert/alert.component.spec.ts
+++ b/web/src/app/modules/overview/components/alert/alert.component.spec.ts
@@ -1,0 +1,47 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AlertComponent } from './alert.component';
+import { By } from '@angular/platform-browser';
+import { DebugElement } from '@angular/core';
+
+describe('AlertComponent', () => {
+  let component: AlertComponent;
+  let fixture: ComponentFixture<AlertComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [AlertComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AlertComponent);
+    component = fixture.componentInstance;
+
+    component.alert = {
+      message: 'message',
+      type: 'warning',
+    };
+
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('sets the alert style', () => {
+    const el: DebugElement = fixture.debugElement.query(By.css('div'));
+    expect(el.classes.hasOwnProperty('alert-warning')).toBeTruthy();
+  });
+
+  it('sets the proper icon', () => {
+    const el: DebugElement = fixture.debugElement.query(By.css('.alert-icon'));
+    expect(el.attributes.shape).toEqual('exclamation-triangle');
+  });
+
+  it('sets the message', () => {
+    const el: DebugElement = fixture.debugElement.query(By.css('.alert-text'));
+    expect(el.nativeElement.textContent.trim()).toBe('message');
+  });
+});

--- a/web/src/app/modules/overview/components/alert/alert.component.ts
+++ b/web/src/app/modules/overview/components/alert/alert.component.ts
@@ -1,0 +1,49 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  OnChanges,
+  OnInit,
+  SimpleChanges,
+} from '@angular/core';
+import { Alert } from '../../../../models/content';
+
+const alertLookup = {
+  error: 'danger',
+  warning: 'warning',
+  info: 'info',
+  success: 'success',
+};
+
+const alertShapes = {
+  danger: 'exclamation-circle',
+  warning: 'exclamation-triangle',
+  info: 'info-circle',
+  success: 'check-circle',
+};
+
+@Component({
+  selector: 'app-alert',
+  templateUrl: './alert.component.html',
+  styleUrls: ['./alert.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AlertComponent implements OnInit {
+  @Input() alert: Alert;
+  shape = '';
+  alertClass = '';
+  message = '';
+  alertType = '';
+
+  constructor() {}
+
+  ngOnInit(): void {
+    if (this.alert) {
+      const alertClass = alertLookup[this.alert.type] || alertLookup.error;
+      this.shape = alertShapes[alertClass];
+      this.alertClass = `alert-${alertClass}`;
+      this.message = this.alert.message;
+      this.alertType = this.alert.type;
+    }
+  }
+}

--- a/web/src/app/modules/overview/components/button-group/button-group.component.html
+++ b/web/src/app/modules/overview/components/button-group/button-group.component.html
@@ -1,0 +1,19 @@
+<clr-button-group *ngIf="view?.config.buttons" class="btn-primary">
+    <clr-button *ngFor="let button of view.config.buttons"
+                class="btn-danger-outline btn-sm"
+            (click)="onClick(button.payload, button.confirmation)">
+
+        {{ button.name }}
+    </clr-button>
+</clr-button-group>
+
+<clr-modal [(clrModalOpen)]="isModalOpen">
+    <h3 class="modal-title">{{modalTitle}}</h3>
+    <div class="modal-body">
+        <div markdown ngPreserveWhitespaces [data]="modalBody"></div>
+    </div>
+    <div class="modal-footer">
+        <button type="button" class="btn btn-outline" (click)="cancelModal()">Cancel</button>
+        <button type="button" class="btn btn-primary" (click)="acceptModal()">OK</button>
+    </div>
+</clr-modal>

--- a/web/src/app/modules/overview/components/button-group/button-group.component.spec.ts
+++ b/web/src/app/modules/overview/components/button-group/button-group.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ButtonGroupComponent } from './button-group.component';
+
+describe('ButtonGroupComponent', () => {
+  let component: ButtonGroupComponent;
+  let fixture: ComponentFixture<ButtonGroupComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ButtonGroupComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ButtonGroupComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/web/src/app/modules/overview/components/button-group/button-group.component.ts
+++ b/web/src/app/modules/overview/components/button-group/button-group.component.ts
@@ -1,0 +1,59 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { ButtonGroupView, Confirmation } from '../../../../models/content';
+import { ActionService } from '../../services/action/action.service';
+
+@Component({
+  selector: 'app-button-group',
+  templateUrl: './button-group.component.html',
+  styleUrls: ['./button-group.component.scss'],
+})
+export class ButtonGroupComponent implements OnInit {
+  @Input() view: ButtonGroupView;
+
+  isModalOpen = false;
+  modalTitle = '';
+  modalBody = '';
+  payload = {};
+
+  constructor(private actionService: ActionService) {}
+
+  ngOnInit() {}
+
+  onClick(payload: {}, confirmation?: Confirmation) {
+    console.log({ payload, confirmation });
+    if (confirmation) {
+      this.activateModal(payload, confirmation);
+    } else {
+      this.doAction(payload);
+    }
+  }
+
+  cancelModal() {
+    this.resetModal();
+  }
+
+  acceptModal() {
+    const payload = this.payload;
+    this.resetModal();
+    this.doAction(payload);
+  }
+
+  private doAction(payload: {}) {
+    this.actionService.perform(payload).subscribe();
+  }
+
+  private activateModal(payload: {}, confirmation: Confirmation) {
+    this.modalTitle = confirmation.title;
+    this.modalBody = confirmation.body;
+    this.isModalOpen = true;
+
+    this.payload = payload;
+  }
+
+  private resetModal() {
+    this.isModalOpen = false;
+    this.modalBody = '';
+    this.modalTitle = '';
+    this.payload = {};
+  }
+}

--- a/web/src/app/modules/overview/components/flexlayout/flexlayout.component.html
+++ b/web/src/app/modules/overview/components/flexlayout/flexlayout.component.html
@@ -1,7 +1,18 @@
+
+
+<div class="clr-row">
+    <div class="clr-col-sm-4 clr-offset-sm-8">
+        <div style="float: right; margin-top: 1em">
+            <app-button-group [view]="view?.config?.buttonGroup"></app-button-group>
+        </div>
+    </div>
+</div>
+
 <ng-container *ngIf="view?.config?.sections">
-  <div class="clr-row" *ngFor="let section of view.config.sections; trackBy: identifySection">
+  <div class="clr-row" *ngFor="let section of view?.config?.sections; trackBy: identifySection">
     <div class="clr-col-md-{{ item.width / 2 }} content-card-parent" *ngFor="let item of section; trackBy: identifySection">
       <app-content-switcher [view]="item.view"></app-content-switcher>
     </div>
   </div>
 </ng-container>
+

--- a/web/src/app/modules/overview/components/flexlayout/flexlayout.component.scss
+++ b/web/src/app/modules/overview/components/flexlayout/flexlayout.component.scss
@@ -8,3 +8,4 @@
     overflow: auto hidden;
   }
 }
+

--- a/web/src/app/modules/overview/components/summary/summary.component.html
+++ b/web/src/app/modules/overview/components/summary/summary.component.html
@@ -18,6 +18,9 @@
         </div>
         <div class="card-block">
             <h3 class="card-title">{{ title }}</h3>
+
+            <app-alert *ngIf="view?.config.alert" [alert]="view.config.alert"></app-alert>
+
             <table class="table table-vertical table-noborder">
                 <tbody>
                 <tr *ngFor="let item of view?.config.sections; trackBy: identifyItem">

--- a/web/src/app/modules/overview/overview.module.ts
+++ b/web/src/app/modules/overview/overview.module.ts
@@ -50,6 +50,8 @@ import { TimestampComponent } from './components/timestamp/timestamp.component';
 import { YamlComponent } from './components/yaml/yaml.component';
 import { OverviewComponent } from './overview.component';
 import { DefaultPipe } from './pipes/default.pipe';
+import { ButtonGroupComponent } from './components/button-group/button-group.component';
+import { AlertComponent } from './components/alert/alert.component';
 
 export function hljsLanguages() {
   return [{ name: 'yaml', func: yaml }, { name: 'json', func: json }];
@@ -96,6 +98,8 @@ export function hljsLanguages() {
     CardListComponent,
     CardComponent,
     CytoscapeComponent,
+    ButtonGroupComponent,
+    AlertComponent,
   ],
   imports: [
     CommonModule,


### PR DESCRIPTION
This change allows pods to be deleted from octant. It has the following changes:

* add a button group component
* create an object delete action handled by the configuration module
* add button groups to flex layout
* add alert to summary