### PR TITLE
Refactor replicaset and deployment printers

### DIFF
--- a/changelogs/unreleased/245-GuessWhoSamFoo
+++ b/changelogs/unreleased/245-GuessWhoSamFoo
@@ -1,0 +1,1 @@
+Change Deployment printer to use ReplicaSet owner reference to get pods

--- a/internal/modules/overview/printer/statefulset.go
+++ b/internal/modules/overview/printer/statefulset.go
@@ -199,6 +199,7 @@ func (statefulSetStatus *StatefulSetStatus) Create() (*component.Quadrant, error
 type statefulSetObject interface {
 	Config(options Options) error
 	Status(ctx context.Context, options Options) error
+	Pods(ctx context.Context, object runtime.Object, options Options) error
 }
 
 type statefulSetHandler struct {


### PR DESCRIPTION
xref: #42 

This PR also traces the owner reference of pods created from a deployment through its replicaset because `pod-template-hash` is deleted from labels.

A separate method for creating a pod list is needed to handle multiple replicasets during a rolling update.

Signed-off-by: GuessWhoSamFoo <foos@vmware.com>