### PR TITLE
Remove informer for CR when it no longer exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ internal/modules/overview/printer/fake
 internal/modules/overview/resourceviewer/fake
 internal/modules/overview/objectvisitor/fake
 internal/portforward/fake
+internal/objectstore/fake
 /pkg/store/fake
 /pkg/plugin/fake
 /pkg/plugin/api/fake

--- a/changelogs/unreleased/250-bryanl
+++ b/changelogs/unreleased/250-bryanl
@@ -1,0 +1,1 @@
+Remove informer for custom resources when they no longer exist

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -36,7 +36,6 @@ import (
 )
 
 //go:generate mockgen -source=cluster.go -destination=./fake/mock_client_interface.go -package=fake github.com/vmware/octant/internal/cluster ClientInterface
-//go:generate mockgen -source=../../vendor/k8s.io/client-go/dynamic/dynamicinformer/interface.go -destination=./fake/mock_dynamicinformer.go -package=fake k8s.io/client-go/dynamic/dynamicinformer DynamicSharedInformerFactory
 //go:generate mockgen -source=../../vendor/k8s.io/client-go/informers/generic.go -destination=./fake/mock_genericinformer.go -package=fake k8s.io/client-go/informers GenericInformer
 //go:generate mockgen -source=../../vendor/k8s.io/client-go/discovery/discovery_client.go -imports=openapi_v2=github.com/googleapis/gnostic/OpenAPIv2 -destination=./fake/mock_discoveryinterface.go -package=fake k8s.io/client-go/discovery DiscoveryInterface
 //go:generate mockgen -source=../../vendor/k8s.io/client-go/kubernetes/clientset.go -destination=./fake/mock_kubernetes_client.go -package=fake -mock_names=Interface=MockKubernetesInterface k8s.io/client-go/kubernetes Interface

--- a/internal/describer/customresource_test.go
+++ b/internal/describer/customresource_test.go
@@ -15,14 +15,14 @@ import (
 
 	"github.com/vmware/octant/internal/testutil"
 	"github.com/vmware/octant/pkg/store"
-	storefake "github.com/vmware/octant/pkg/store/fake"
+	storeFake "github.com/vmware/octant/pkg/store/fake"
 )
 
 func Test_customResourceDefinition(t *testing.T) {
 	controller := gomock.NewController(t)
 	defer controller.Finish()
 
-	o := storefake.NewMockStore(controller)
+	o := storeFake.NewMockStore(controller)
 
 	crd1 := testutil.CreateCRD("crd1.example.com")
 

--- a/internal/modules/clusteroverview/clusteroverview.go
+++ b/internal/modules/clusteroverview/clusteroverview.go
@@ -68,6 +68,7 @@ func New(ctx context.Context, options Options) (*ClusterOverview, error) {
 	}
 
 	crdWatcher := options.DashConfig.CRDWatcher()
+	objectStore := co.DashConfig.ObjectStore()
 	watchConfig := &config.CRDWatchConfig{
 		Add: func(_ *describer.PathMatcher, sectionDescriber *describer.CRDSection) config.ObjectHandler {
 			return func(ctx context.Context, object *unstructured.Unstructured) {
@@ -82,7 +83,7 @@ func New(ctx context.Context, options Options) (*ClusterOverview, error) {
 				if object == nil {
 					return
 				}
-				describer.DeleteCRD(ctx, object, pathMatcher, customResourcesDescriber, co)
+				describer.DeleteCRD(ctx, object, pathMatcher, customResourcesDescriber, co, objectStore)
 			}
 		}(pathMatcher, customResourcesDescriber),
 		IsNamespaced: false,

--- a/internal/modules/overview/overview.go
+++ b/internal/modules/overview/overview.go
@@ -120,6 +120,7 @@ func (co *Overview) bootstrap(ctx context.Context) error {
 
 	crdWatcher := co.dashConfig.CRDWatcher()
 
+	objectStore := co.dashConfig.ObjectStore()
 	watchConfig := &config.CRDWatchConfig{
 		Add: func(_ *describer.PathMatcher, sectionDescriber *describer.CRDSection) config.ObjectHandler {
 			return func(ctx context.Context, object *unstructured.Unstructured) {
@@ -134,7 +135,7 @@ func (co *Overview) bootstrap(ctx context.Context) error {
 				if object == nil {
 					return
 				}
-				describer.DeleteCRD(ctx, object, pathMatcher, customResourcesDescriber, co)
+				describer.DeleteCRD(ctx, object, pathMatcher, customResourcesDescriber, co, objectStore)
 			}
 		}(pathMatcher, customResourcesDescriber),
 		IsNamespaced: true,

--- a/internal/objectstore/informer.go
+++ b/internal/objectstore/informer.go
@@ -1,0 +1,98 @@
+package objectstore
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+)
+
+//go:generate mockgen -destination=./fake/mock_informer_factory.go -package=fake github.com/vmware/octant/internal/objectstore InformerFactory
+
+// InformerFactory creates informers.
+type InformerFactory interface {
+	ForResource(gvr schema.GroupVersionResource) informers.GenericInformer
+	Delete(gvr schema.GroupVersionResource)
+	WaitForCacheSync(stopCh <-chan struct{}) map[schema.GroupVersionResource]bool
+}
+
+type informerFactory struct {
+	client        dynamic.Interface
+	defaultResync time.Duration
+	namespace     string
+
+	lock                 sync.Mutex
+	informers            map[schema.GroupVersionResource]informers.GenericInformer
+	tweakListOptions     dynamicinformer.TweakListOptionsFunc
+	stopCh               <-chan struct{}
+	informerContextCache *informerContextCache
+}
+
+var _ InformerFactory = (*informerFactory)(nil)
+
+func newInformerFactory(stopCh <-chan struct{}, client dynamic.Interface, defaultResync time.Duration, namespace string) *informerFactory {
+	return &informerFactory{
+		stopCh:               stopCh,
+		client:               client,
+		defaultResync:        defaultResync,
+		namespace:            namespace,
+		informers:            map[schema.GroupVersionResource]informers.GenericInformer{},
+		informerContextCache: initInformerContextCache(),
+	}
+}
+
+// ForResource creates an informer and starts it given a group/version/resource.
+func (f *informerFactory) ForResource(gvr schema.GroupVersionResource) informers.GenericInformer {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	key := gvr
+	informer, exists := f.informers[key]
+	if exists && informer != nil {
+		return informer
+	}
+
+	informer = dynamicinformer.NewFilteredDynamicInformer(f.client, gvr, f.namespace, f.defaultResync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	f.informers[key] = informer
+
+	stopCh := f.informerContextCache.addChild(gvr)
+	go informer.Informer().Run(stopCh)
+
+	return informer
+}
+
+// Delete deletes an informer given a a group/version/resource.
+func (f *informerFactory) Delete(gvr schema.GroupVersionResource) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	if _, ok := f.informers[gvr]; ok {
+		f.informerContextCache.delete(gvr)
+		delete(f.informers, gvr)
+		f.informers[gvr] = nil
+	}
+}
+
+// WaitForCacheSync waits for all started informers' cache were synced.
+func (f *informerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[schema.GroupVersionResource]bool {
+	list := func() map[schema.GroupVersionResource]cache.SharedIndexInformer {
+		f.lock.Lock()
+		defer f.lock.Unlock()
+
+		shared := map[schema.GroupVersionResource]cache.SharedIndexInformer{}
+		for informerType, informer := range f.informers {
+			shared[informerType] = informer.Informer()
+		}
+		return shared
+	}()
+
+	res := map[schema.GroupVersionResource]bool{}
+	for informType, informer := range list {
+		res[informType] = cache.WaitForCacheSync(stopCh, informer.HasSynced)
+	}
+	return res
+}

--- a/internal/octant/object_path.go
+++ b/internal/octant/object_path.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/vmware/octant/internal/log"
+	"github.com/vmware/octant/internal/util/kubernetes"
 	dashStrings "github.com/vmware/octant/internal/util/strings"
 )
 
@@ -138,19 +139,19 @@ func (op *ObjectPath) SupportedGroupVersionKind() []schema.GroupVersionKind {
 	op.mu.Lock()
 	defer op.mu.Unlock()
 
-	gvks := make([]schema.GroupVersionKind, len(op.supportedGVKs))
-	copy(gvks, op.supportedGVKs)
+	list := make([]schema.GroupVersionKind, len(op.supportedGVKs))
+	copy(list, op.supportedGVKs)
 
 	for _, crd := range op.crds {
-		r, err := CRDResourceGVKs(crd)
+		r, err := kubernetes.CRDResources(crd)
 		if err != nil {
 			continue
 		}
 
-		gvks = append(gvks, r...)
+		list = append(list, r...)
 	}
 
-	return gvks
+	return list
 }
 
 // GroupVersionKind returns a path for an object.
@@ -158,13 +159,13 @@ func (op *ObjectPath) GroupVersionKindPath(namespace, apiVersion, kind, name str
 	op.mu.Lock()
 	defer op.mu.Unlock()
 
-	gvk := schema.FromAPIVersionAndKind(apiVersion, kind)
+	g := schema.FromAPIVersionAndKind(apiVersion, kind)
 
 	// if apiVersion matches a crd, build up path dynamically
 	for i := range op.crds {
 		crd := op.crds[i]
 
-		supports, err := crdSupportsGVK(crd, gvk)
+		supports, err := kubernetes.CRDContainsResource(crd, g)
 		if err != nil {
 			return "", err
 		}
@@ -191,128 +192,18 @@ func (op *ObjectPath) GroupVersionKindPath(namespace, apiVersion, kind, name str
 	return op.lookupFunc(namespace, apiVersion, kind, name)
 }
 
-// CRDResourceGVKs returns the GVKs contained within a CRD.
-func CRDResourceGVKs(crd *unstructured.Unstructured) ([]schema.GroupVersionKind, error) {
-	apiVersions, err := CRDAPIVersions(crd)
+// CRDAPIVersions returns the group versions that are contained within a CRD.
+func CRDAPIVersions(crd *unstructured.Unstructured) ([]schema.GroupVersion, error) {
+
+	resources, err := kubernetes.CRDResources(crd)
 	if err != nil {
 		return nil, err
 	}
 
-	spec, ok := crd.Object["spec"].(map[string]interface{})
-	if !ok {
-		return nil, errors.New("crd did not have spec")
-	}
-
-	names, ok := spec["names"].(map[string]interface{})
-	if !ok {
-		return nil, errors.New("crd spec did not have names")
-	}
-
-	kind, ok := names["kind"].(string)
-	if !ok {
-		return nil, errors.New("crd spec names did not have kind")
-	}
-
-	var list []schema.GroupVersionKind
-
-	for _, apiVersion := range apiVersions {
-		list = append(list, schema.GroupVersionKind{Group: apiVersion.Group, Version: apiVersion.Version, Kind: kind})
+	list := make([]schema.GroupVersion, len(resources))
+	for i := range resources {
+		list[i] = resources[i].GroupVersion()
 	}
 
 	return list, nil
-}
-
-// CRDAPIVersions returns the group versions that are contained within a CRD.
-func CRDAPIVersions(crd *unstructured.Unstructured) ([]schema.GroupVersion, error) {
-	if crd == nil {
-		return nil, errors.New("crd is nil")
-	}
-
-	var list []schema.GroupVersion
-
-	spec, ok := crd.Object["spec"].(map[string]interface{})
-	if !ok {
-		return nil, errors.New("crd did not have spec")
-	}
-
-	crdName, ok := spec["group"].(string)
-	if !ok {
-		return nil, errors.New("crd spec did not have group")
-	}
-
-	versions, ok := spec["versions"].([]interface{})
-	if !ok {
-		return nil, errors.New("crd spec did not have versions")
-	}
-
-	for _, rawVersion := range versions {
-		version, ok := rawVersion.(map[string]interface{})
-		if !ok {
-			return nil, errors.New("crd version was not an object")
-		}
-
-		versionName, ok := version["name"].(string)
-		if !ok {
-			return nil, errors.New("crd version did not have a name")
-		}
-
-		list = append(list, schema.GroupVersion{Group: crdName, Version: versionName})
-	}
-
-	return list, nil
-}
-
-func crdSupportsGVK(crd *unstructured.Unstructured, gvk schema.GroupVersionKind) (bool, error) {
-	if crd == nil {
-		return false, errors.New("crd is nil")
-	}
-
-	spec, ok := crd.Object["spec"].(map[string]interface{})
-	if !ok {
-		return false, errors.New("crd did not have spec")
-	}
-
-	group, ok := spec["group"].(string)
-	if !ok {
-		return false, errors.New("crd spec did not have group")
-	}
-
-	names, ok := spec["names"].(map[string]interface{})
-	if !ok {
-		return false, errors.New("crd spec did not have names")
-	}
-
-	kind, ok := names["kind"].(string)
-	if !ok {
-		return false, errors.New("crd spec names did not have kind")
-	}
-
-	rawVersions, ok := spec["versions"].([]interface{})
-	if !ok {
-		return false, errors.New("crd spec did not have versions")
-	}
-
-	for _, rawVersion := range rawVersions {
-		version, ok := rawVersion.(map[string]interface{})
-		if !ok {
-			return false, errors.New("crd version was not an object")
-		}
-
-		versionName, ok := version["name"].(string)
-		if !ok {
-			return false, errors.New("crd version did not have a name")
-		}
-
-		current := schema.GroupVersionKind{
-			Group:   group,
-			Kind:    kind,
-			Version: versionName,
-		}
-
-		if current.String() == gvk.String() {
-			return true, nil
-		}
-	}
-
-	return false, nil
 }

--- a/internal/octant/object_path_test.go
+++ b/internal/octant/object_path_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/vmware/octant/internal/testutil"
@@ -72,18 +71,7 @@ func TestObjectPath(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	crd := testutil.CreateCRD("my-crd")
-	crd.Spec.Group = "group"
-
-	crd.Spec.Versions = []apiextv1beta1.CustomResourceDefinitionVersion{
-		{
-			Name: "v1",
-		},
-	}
-
-	crd.Spec.Names = apiextv1beta1.CustomResourceDefinitionNames{
-		Kind: "kind",
-	}
+	crd := testutil.CreateCRD("my-crd", testutil.WithGenericCRD())
 
 	err = objectPath.AddCRD(ctx, testutil.ToUnstructured(t, crd))
 	require.NoError(t, err)
@@ -104,40 +92,8 @@ func TestObjectPath(t *testing.T) {
 	require.NotContains(t, objectPath.crds, crd.Name)
 }
 
-func TestCRDResourceGVKs(t *testing.T) {
-	crd := testutil.CreateCRD("my-crd")
-	crd.Spec.Group = "group"
-
-	crd.Spec.Versions = []apiextv1beta1.CustomResourceDefinitionVersion{
-		{
-			Name: "v1",
-		},
-	}
-
-	crd.Spec.Names = apiextv1beta1.CustomResourceDefinitionNames{
-		Kind: "kind",
-	}
-
-	got, err := CRDResourceGVKs(testutil.ToUnstructured(t, crd))
-	require.NoError(t, err)
-
-	expected := []schema.GroupVersionKind{
-		{Group: "group", Version: "v1", Kind: "kind"},
-	}
-
-	assert.Equal(t, expected, got)
-}
-
 func TestCRDAPIVersions(t *testing.T) {
-	crd := testutil.CreateCRD("my-crd")
-	crd.Spec.Group = "group"
-
-	crd.Spec.Versions = []apiextv1beta1.CustomResourceDefinitionVersion{
-		{
-			Name: "v1",
-		},
-	}
-
+	crd := testutil.CreateCRD("my-crd", testutil.WithGenericCRD())
 	got, err := CRDAPIVersions(testutil.ToUnstructured(t, crd))
 	require.NoError(t, err)
 

--- a/internal/testutil/generator.go
+++ b/internal/testutil/generator.go
@@ -50,12 +50,35 @@ func CreateConfigMap(name string) *corev1.ConfigMap {
 	}
 }
 
+// CRDOption is an option for configuring CreateCRD.
+type CRDOption func(definition *apiextv1beta1.CustomResourceDefinition)
+
+// WithGenericCRD creates a crd with group/kind and one version
+func WithGenericCRD() CRDOption {
+	return func(crd *apiextv1beta1.CustomResourceDefinition) {
+		crd.Spec.Group = "group"
+		crd.Spec.Versions = []apiextv1beta1.CustomResourceDefinitionVersion{
+			{
+				Name:   "v1",
+				Served: true,
+			},
+		}
+		crd.Spec.Names.Kind = "kind"
+	}
+}
+
 // CreateCRD creates a CRD
-func CreateCRD(name string) *apiextv1beta1.CustomResourceDefinition {
-	return &apiextv1beta1.CustomResourceDefinition{
+func CreateCRD(name string, options ...CRDOption) *apiextv1beta1.CustomResourceDefinition {
+	crd := &apiextv1beta1.CustomResourceDefinition{
 		TypeMeta:   genTypeMeta(gvk.CustomResourceDefinition),
 		ObjectMeta: genObjectMeta(name, true),
 	}
+
+	for _, option := range options {
+		option(crd)
+	}
+
+	return crd
 }
 
 // CreateCustomResource creates a custom resource.

--- a/internal/util/kubernetes/customresource.go
+++ b/internal/util/kubernetes/customresource.go
@@ -1,0 +1,117 @@
+package kubernetes
+
+import (
+	"errors"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// CRDResources returns a list of resources identified by group/version/kind a CRD supports.
+func CRDResources(crd *unstructured.Unstructured) ([]schema.GroupVersionKind, error) {
+	if crd == nil {
+		return nil, errors.New("crd is nil")
+	}
+
+	var list []schema.GroupVersionKind
+
+	group, ok, err := unstructured.NestedString(crd.Object, "spec", "group")
+	if err != nil {
+		return nil, err
+	}
+
+	if !ok {
+		return nil, errors.New("crd did not have a spec.group")
+	}
+
+	kind, ok, err := unstructured.NestedString(crd.Object, "spec", "names", "kind")
+	if err != nil {
+		return nil, err
+	}
+
+	if !ok {
+		return nil, errors.New("crd did not have a spec.names.kind")
+	}
+
+	versionsRaw, ok, err := unstructured.NestedSlice(crd.Object, "spec", "versions")
+	if err != nil {
+		return nil, err
+	}
+
+	if ok {
+		for _, versionRaw := range versionsRaw {
+			version, ok := versionRaw.(map[string]interface{})
+			if !ok {
+				return nil, errors.New("version was of an unknown type")
+			}
+
+			isServed, ok, err := unstructured.NestedBool(version, "served")
+			if err != nil {
+				return nil, err
+			}
+
+			if !ok {
+				return nil, errors.New("version doesn't have served entry")
+			}
+
+			name, ok, err := unstructured.NestedString(version, "name")
+			if err != nil {
+				return nil, err
+			}
+
+			if !ok {
+				return nil, errors.New("version doesn't have name")
+			}
+
+			if isServed {
+				g := schema.GroupVersionKind{
+					Group:   group,
+					Version: name,
+					Kind:    kind,
+				}
+				if !groupVersionKindsContains(g, list) {
+					list = append(list, g)
+				}
+
+			}
+		}
+	}
+
+	version, ok, err := unstructured.NestedString(crd.Object, "spec", "version")
+	if err != nil {
+		return nil, err
+	}
+
+	if ok {
+		g := schema.GroupVersionKind{
+			Group:   group,
+			Version: version,
+			Kind:    kind,
+		}
+		if !groupVersionKindsContains(g, list) {
+			list = append(list, g)
+		}
+
+	}
+
+	return list, nil
+}
+
+// CRDContainsResource returns true if a CRD contains a resource.
+func CRDContainsResource(crd *unstructured.Unstructured, g schema.GroupVersionKind) (bool, error) {
+	list, err := CRDResources(crd)
+	if err != nil {
+		return false, err
+	}
+
+	return groupVersionKindsContains(g, list), nil
+}
+
+func groupVersionKindsContains(g schema.GroupVersionKind, list []schema.GroupVersionKind) bool {
+	for i := range list {
+		if g.String() == list[i].String() {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/util/kubernetes/customresource_test.go
+++ b/internal/util/kubernetes/customresource_test.go
@@ -1,0 +1,75 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/vmware/octant/internal/testutil"
+)
+
+func Test_CRDResources(t *testing.T) {
+	crd1 := testutil.CreateCRD("test")
+	crd1.Spec.Group = "group"
+	crd1.Spec.Names.Kind = "kind"
+	crd1.Spec.Version = ""
+	crd1.Spec.Versions = []apiextv1beta1.CustomResourceDefinitionVersion{
+		{
+			Name:   "v1",
+			Served: true,
+		},
+	}
+
+	crd2 := testutil.CreateCRD("test")
+	crd2.Spec.Group = "group"
+	crd2.Spec.Names.Kind = "kind"
+	crd2.Spec.Version = "v1"
+
+	tests := []struct {
+		name     string
+		crd      *unstructured.Unstructured
+		expected []schema.GroupVersionKind
+		isErr    bool
+	}{
+		{
+			name: "with versions",
+			crd:  testutil.ToUnstructured(t, crd1),
+			expected: []schema.GroupVersionKind{
+				{
+					Group:   "group",
+					Version: "v1",
+					Kind:    "kind",
+				},
+			},
+		},
+		{
+			name: "with version (deprecated)",
+			crd:  testutil.ToUnstructured(t, crd1),
+			expected: []schema.GroupVersionKind{
+				{
+					Group:   "group",
+					Version: "v1",
+					Kind:    "kind",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := CRDResources(test.crd)
+			if test.isErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expected, got)
+		})
+	}
+
+}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -32,6 +32,7 @@ type Store interface {
 	Get(ctx context.Context, key Key) (object *unstructured.Unstructured, found bool, err error)
 	Delete(ctx context.Context, key Key) error
 	Watch(ctx context.Context, key Key, handler cache.ResourceEventHandler) error
+	Unwatch(ctx context.Context, groupVersionKinds ...schema.GroupVersionKind) error
 	UpdateClusterClient(ctx context.Context, client cluster.ClientInterface) error
 	RegisterOnUpdate(fn UpdateFn)
 	Update(ctx context.Context, key Key, updater func(*unstructured.Unstructured) error) error


### PR DESCRIPTION
When a custom resource no longer exists, remove the informer that pointed to the custom resource.

This change also consolidates operations around determining which custom resources belong to a custom resource definition.