### PR TITLE
use dynamic client when cache has not synced

### DIFF
--- a/changelogs/unreleased/268-bryanl
+++ b/changelogs/unreleased/268-bryanl
@@ -1,0 +1,1 @@
+Use dynamic client when informer cache has not synced

--- a/internal/objectstore/dynamic_cache_test.go
+++ b/internal/objectstore/dynamic_cache_test.go
@@ -13,13 +13,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	authorizationv1 "k8s.io/api/authorization/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	kLabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicFake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/informers"
-	testing2 "k8s.io/client-go/testing"
+	clientGoTesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/vmware/octant/internal/cluster"
@@ -27,6 +28,10 @@ import (
 	"github.com/vmware/octant/internal/objectstore/fake"
 	"github.com/vmware/octant/internal/testutil"
 	"github.com/vmware/octant/pkg/store"
+)
+
+var (
+	podGVR = schema.GroupVersionResource{Version: "v1", Resource: "pods"}
 )
 
 type fakeLister struct {
@@ -66,67 +71,27 @@ func expectNamespaceAccess(
 }
 
 func Test_DynamicCache_List(t *testing.T) {
+	h := initDynamicCacheTestHarness(t)
+	defer h.finish()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	controller := gomock.NewController(t)
-	defer controller.Finish()
-
-	client := clusterFake.NewMockClientInterface(controller)
-	informerFactory := fake.NewMockInformerFactory(controller)
-	genericInformer := clusterFake.NewMockGenericInformer(controller)
-	kubernetesClient := clusterFake.NewMockKubernetesInterface(controller)
-	authClient := clusterFake.NewMockAuthorizationV1Interface(controller)
-	accessClient := clusterFake.NewMockSelfSubjectAccessReviewInterface(controller)
-	namespaceClient := clusterFake.NewMockNamespaceInterface(controller)
-
 	pod := testutil.CreatePod("pod")
+
 	objects := []runtime.Object{testutil.ToUnstructured(t, pod)}
 
-	podGVR := schema.GroupVersionResource{
-		Version:  "v1",
-		Resource: "pods",
-	}
-	informerFactory.EXPECT().ForResource(gomock.Eq(podGVR)).Return(genericInformer)
-
-	podGK := schema.GroupKind{
-		Kind: "Pod",
-	}
-	// CheckAccess and currentInformer
-	client.EXPECT().Resource(gomock.Eq(podGK)).Return(podGVR, nil).MaxTimes(2)
-
-	client.EXPECT().KubernetesClient().Return(kubernetesClient, nil)
-	kubernetesClient.EXPECT().AuthorizationV1().Return(authClient)
-
-	client.EXPECT().NamespaceClient().Return(namespaceClient, nil).MaxTimes(2)
-	namespaces := []string{"test", ""}
-	namespaceClient.EXPECT().Names().Return(namespaces, nil).MaxTimes(2)
-
-	expectNamespaceAccess(accessClient, authClient, len(namespaces))
-
 	l := &fakeLister{listObjects: objects}
-	genericInformer.EXPECT().Lister().Return(l)
+	h.setupLister(podGVR, l)
 
-	factoryFunc := func(c *DynamicCache) {
-		c.initFactoryFunc = func(i context.Context, clientInterface cluster.ClientInterface, s string) (factory InformerFactory, e error) {
-			return informerFactory, nil
+	h.mapResources(pod.GroupVersionKind(), podGVR)
 
-		}
-		c.waitForSyncFunc = func(context.Context, store.Key, *DynamicCache, informers.GenericInformer, chan bool) {
-			return
-		}
-	}
-
-	resourceAccess := NewResourceAccess(client)
-
-	c, err := NewDynamicCache(ctx, client, factoryFunc, Access(resourceAccess))
+	c, err := h.factory(ctx)
 	require.NoError(t, err)
 
-	key := store.Key{
-		Namespace:  "test",
-		APIVersion: "v1",
-		Kind:       "Pod",
-	}
+	h.setSynced(t, c, pod)
+
+	key := h.keyFromObject(t, pod)
 
 	got, isLoading, err := c.List(ctx, key)
 	require.NoError(t, err)
@@ -137,65 +102,23 @@ func Test_DynamicCache_List(t *testing.T) {
 }
 
 func Test_DynamicCache_Get(t *testing.T) {
+	h := initDynamicCacheTestHarness(t)
+	defer h.finish()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	controller := gomock.NewController(t)
-	defer controller.Finish()
-
-	client := clusterFake.NewMockClientInterface(controller)
-	informerFactory := fake.NewMockInformerFactory(controller)
-	genericInformer := clusterFake.NewMockGenericInformer(controller)
-	kubernetesClient := clusterFake.NewMockKubernetesInterface(controller)
-	authClient := clusterFake.NewMockAuthorizationV1Interface(controller)
-	accessClient := clusterFake.NewMockSelfSubjectAccessReviewInterface(controller)
-	namespaceClient := clusterFake.NewMockNamespaceInterface(controller)
-
 	pod := testutil.CreatePod("pod")
 
-	podGVR := schema.GroupVersionResource{
-		Version:  "v1",
-		Resource: "pods",
-	}
-	informerFactory.EXPECT().ForResource(gomock.Eq(podGVR)).Return(genericInformer)
-
-	podGK := schema.GroupKind{
-		Kind: "Pod",
-	}
-	// CheckAccess and currentInformer
-	client.EXPECT().Resource(gomock.Eq(podGK)).Return(podGVR, nil).MaxTimes(2)
-
-	client.EXPECT().KubernetesClient().Return(kubernetesClient, nil)
-	kubernetesClient.EXPECT().AuthorizationV1().Return(authClient)
-
-	client.EXPECT().NamespaceClient().Return(namespaceClient, nil).MaxTimes(2)
-	namespaces := []string{"test", ""}
-	namespaceClient.EXPECT().Names().Return(namespaces, nil).MaxTimes(2)
-
-	expectNamespaceAccess(accessClient, authClient, len(namespaces))
-
 	l := &fakeLister{getObject: testutil.ToUnstructured(t, pod)}
-	genericInformer.EXPECT().Lister().Return(l)
+	h.setupLister(podGVR, l)
+	h.mapResources(pod.GroupVersionKind(), podGVR)
 
-	factoryFunc := func(c *DynamicCache) {
-		c.initFactoryFunc = func(i context.Context, clientInterface cluster.ClientInterface, s string) (factory InformerFactory, e error) {
-			return informerFactory, nil
-
-		}
-		c.waitForSyncFunc = func(context.Context, store.Key, *DynamicCache, informers.GenericInformer, chan bool) {
-			return
-		}
-	}
-	resourceAccess := NewResourceAccess(client)
-	c, err := NewDynamicCache(ctx, client, factoryFunc, Access(resourceAccess))
+	c, err := h.factory(ctx)
 	require.NoError(t, err)
 
-	key := store.Key{
-		Namespace:  "test",
-		APIVersion: "v1",
-		Kind:       "Pod",
-		Name:       "pod",
-	}
+	h.setSynced(t, c, pod)
+	key := h.keyFromObject(t, pod)
 
 	got, found, err := c.Get(ctx, key)
 	require.NoError(t, err)
@@ -207,67 +130,30 @@ func Test_DynamicCache_Get(t *testing.T) {
 }
 
 func TestDynamicCache_Update(t *testing.T) {
+	h := initDynamicCacheTestHarness(t)
+	defer h.finish()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	pod := testutil.ToUnstructured(t, testutil.CreatePod("pod"))
 
-	controller := gomock.NewController(t)
-	defer controller.Finish()
-
-	client := clusterFake.NewMockClientInterface(controller)
-	informerFactory := fake.NewMockInformerFactory(controller)
-	genericInformer := clusterFake.NewMockGenericInformer(controller)
-	kubernetesClient := clusterFake.NewMockKubernetesInterface(controller)
-	authClient := clusterFake.NewMockAuthorizationV1Interface(controller)
-	accessClient := clusterFake.NewMockSelfSubjectAccessReviewInterface(controller)
-	namespaceClient := clusterFake.NewMockNamespaceInterface(controller)
-
-	podGVR := schema.GroupVersionResource{
-		Version:  "v1",
-		Resource: "pods",
-	}
-	informerFactory.EXPECT().ForResource(gomock.Eq(podGVR)).Return(genericInformer)
-
-	podGK := schema.GroupKind{
-		Kind: "Pod",
-	}
-	// CheckAccess and currentInformer
-	client.EXPECT().Resource(gomock.Eq(podGK)).Return(podGVR, nil).AnyTimes()
-
-	client.EXPECT().KubernetesClient().Return(kubernetesClient, nil)
-	kubernetesClient.EXPECT().AuthorizationV1().Return(authClient)
-
-	client.EXPECT().NamespaceClient().Return(namespaceClient, nil).AnyTimes()
-	namespaces := []string{"test", ""}
-	namespaceClient.EXPECT().Names().Return(namespaces, nil).AnyTimes()
-
-	expectNamespaceAccess(accessClient, authClient, len(namespaces))
+	podInformer := h.informerFor(podGVR)
+	h.mapResources(pod.GroupVersionKind(), podGVR)
 
 	l := &fakeLister{getObject: pod}
-	genericInformer.EXPECT().Lister().Return(l)
+	podInformer.EXPECT().Lister().Return(l)
 
-	factoryFunc := func(c *DynamicCache) {
-		c.initFactoryFunc = func(i context.Context, clientInterface cluster.ClientInterface, s string) (factory InformerFactory, e error) {
-			return informerFactory, nil
-
-		}
-		c.waitForSyncFunc = func(context.Context, store.Key, *DynamicCache, informers.GenericInformer, chan bool) {
-			return
-		}
-	}
 	scheme := runtime.NewScheme()
 
 	dc := dynamicFake.NewSimpleDynamicClient(scheme, pod)
 
-	client.EXPECT().DynamicClient().Return(dc, nil)
+	h.client.EXPECT().DynamicClient().Return(dc, nil)
 
-	resourceAccess := NewResourceAccess(client)
-	c, err := NewDynamicCache(ctx, client, factoryFunc, Access(resourceAccess))
+	c, err := h.factory(ctx)
 	require.NoError(t, err)
 
-	key, err := store.KeyFromObject(pod)
-	require.NoError(t, err)
+	key := h.keyFromObject(t, pod)
 
 	err = c.Update(ctx, key, func(*unstructured.Unstructured) error {
 		return nil
@@ -281,71 +167,32 @@ func TestDynamicCache_Update(t *testing.T) {
 }
 
 func TestDynamicCache_Delete(t *testing.T) {
+	h := initDynamicCacheTestHarness(t)
+	defer h.finish()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	pod := testutil.ToUnstructured(t, testutil.CreatePod("pod"))
-
-	controller := gomock.NewController(t)
-	defer controller.Finish()
-
-	client := clusterFake.NewMockClientInterface(controller)
-	informerFactory := fake.NewMockInformerFactory(controller)
-	kubernetesClient := clusterFake.NewMockKubernetesInterface(controller)
-	authClient := clusterFake.NewMockAuthorizationV1Interface(controller)
-	accessClient := clusterFake.NewMockSelfSubjectAccessReviewInterface(controller)
-	namespaceClient := clusterFake.NewMockNamespaceInterface(controller)
-
-	podGVR := schema.GroupVersionResource{
-		Version:  "v1",
-		Resource: "pods",
-	}
-
-	podGK := schema.GroupKind{
-		Kind: "Pod",
-	}
-	// CheckAccess and currentInformer
-	client.EXPECT().Resource(gomock.Eq(podGK)).Return(podGVR, nil).AnyTimes()
-
-	client.EXPECT().KubernetesClient().Return(kubernetesClient, nil)
-	kubernetesClient.EXPECT().AuthorizationV1().Return(authClient)
-
-	client.EXPECT().NamespaceClient().Return(namespaceClient, nil).AnyTimes()
-	namespaces := []string{"test", ""}
-	namespaceClient.EXPECT().Names().Return(namespaces, nil).AnyTimes()
-
-	expectNamespaceAccess(accessClient, authClient, len(namespaces))
-
-	factoryFunc := func(c *DynamicCache) {
-		c.initFactoryFunc = func(i context.Context, clientInterface cluster.ClientInterface, s string) (factory InformerFactory, e error) {
-			return informerFactory, nil
-
-		}
-		c.waitForSyncFunc = func(context.Context, store.Key, *DynamicCache, informers.GenericInformer, chan bool) {
-			return
-		}
-	}
+	h.mapResources(pod.GroupVersionKind(), podGVR)
 
 	scheme := runtime.NewScheme()
 
 	dc := dynamicFake.NewSimpleDynamicClient(scheme, pod)
+	h.client.EXPECT().DynamicClient().Return(dc, nil)
 
-	client.EXPECT().DynamicClient().Return(dc, nil)
-
-	resourceAccess := NewResourceAccess(client)
-	c, err := NewDynamicCache(ctx, client, factoryFunc, Access(resourceAccess))
+	c, err := h.factory(ctx)
 	require.NoError(t, err)
 
-	key, err := store.KeyFromObject(pod)
-	require.NoError(t, err)
+	key := h.keyFromObject(t, pod)
 
 	err = c.Delete(ctx, key)
 	require.NoError(t, err)
 
 	assert.Len(t, dc.Actions(), 1)
 
-	expected := testing2.DeleteActionImpl{
-		ActionImpl: testing2.ActionImpl{
+	expected := clientGoTesting.DeleteActionImpl{
+		ActionImpl: clientGoTesting.ActionImpl{
 			Namespace: pod.GetNamespace(),
 			Verb:      "delete",
 			Resource:  podGVR,
@@ -358,43 +205,70 @@ func TestDynamicCache_Delete(t *testing.T) {
 }
 
 func TestDynamicCache_Unwatch(t *testing.T) {
+	h := initDynamicCacheTestHarness(t)
+	defer h.finish()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	controller := gomock.NewController(t)
-	defer controller.Finish()
+	pod := testutil.CreatePod("pod")
+	h.mapResources(pod.GroupVersionKind(), podGVR)
 
+	c, err := h.factory(ctx)
+	require.NoError(t, err)
+
+	h.informerFactory.EXPECT().Delete(podGVR)
+
+	err = c.Unwatch(ctx, pod.GroupVersionKind())
+	require.NoError(t, err)
+}
+
+type dynamicCacheTestHarness struct {
+	controller       *gomock.Controller
+	client           *clusterFake.MockClientInterface
+	informerFactory  *fake.MockInformerFactory
+	kubernetesClient *clusterFake.MockKubernetesInterface
+	authClient       *clusterFake.MockAuthorizationV1Interface
+	namespaceClient  *clusterFake.MockNamespaceInterface
+	accessClient     *clusterFake.MockSelfSubjectAccessReviewInterface
+}
+
+func initDynamicCacheTestHarness(t *testing.T) *dynamicCacheTestHarness {
+	controller := gomock.NewController(t)
 	client := clusterFake.NewMockClientInterface(controller)
 	informerFactory := fake.NewMockInformerFactory(controller)
+	kubernetesClient := clusterFake.NewMockKubernetesInterface(controller)
 	authClient := clusterFake.NewMockAuthorizationV1Interface(controller)
 	accessClient := clusterFake.NewMockSelfSubjectAccessReviewInterface(controller)
 	namespaceClient := clusterFake.NewMockNamespaceInterface(controller)
 
-	podGVR := schema.GroupVersionResource{
-		Version:  "v1",
-		Resource: "pods",
-	}
-
-	podGK := schema.GroupKind{
-		Kind: "Pod",
-	}
-	// CheckAccess and currentInformer
-	client.EXPECT().Resource(gomock.Eq(podGK)).Return(podGVR, nil).AnyTimes()
-
-	client.EXPECT().NamespaceClient().Return(namespaceClient, nil).AnyTimes()
 	namespaces := []string{"test", ""}
-	namespaceClient.EXPECT().Names().Return(namespaces, nil).AnyTimes()
-
+	client.EXPECT().NamespaceClient().Return(namespaceClient, nil).AnyTimes()
+	namespaceClient.EXPECT().Names().Return(namespaces, nil).MaxTimes(2)
 	expectNamespaceAccess(accessClient, authClient, len(namespaces))
 
-	informerFactory.EXPECT().Delete(schema.GroupVersionResource{
-		Version:  "v1",
-		Resource: "pods",
-	})
+	client.EXPECT().KubernetesClient().Return(kubernetesClient, nil).AnyTimes()
+	kubernetesClient.EXPECT().AuthorizationV1().Return(authClient).AnyTimes()
 
+	return &dynamicCacheTestHarness{
+		controller:       controller,
+		client:           client,
+		informerFactory:  informerFactory,
+		kubernetesClient: kubernetesClient,
+		authClient:       authClient,
+		accessClient:     accessClient,
+		namespaceClient:  namespaceClient,
+	}
+}
+
+func (h *dynamicCacheTestHarness) finish() {
+	h.controller.Finish()
+}
+
+func (h *dynamicCacheTestHarness) factory(ctx context.Context) (*DynamicCache, error) {
 	factoryFunc := func(c *DynamicCache) {
 		c.initFactoryFunc = func(i context.Context, clientInterface cluster.ClientInterface, s string) (factory InformerFactory, e error) {
-			return informerFactory, nil
+			return h.informerFactory, nil
 
 		}
 		c.waitForSyncFunc = func(context.Context, store.Key, *DynamicCache, informers.GenericInformer, chan bool) {
@@ -402,13 +276,47 @@ func TestDynamicCache_Unwatch(t *testing.T) {
 		}
 	}
 
-	resourceAccess := NewResourceAccess(client)
-	c, err := NewDynamicCache(ctx, client, factoryFunc, Access(resourceAccess))
+	resourceAccess := NewResourceAccess(h.client)
+	return NewDynamicCache(ctx, h.client, factoryFunc, Access(resourceAccess))
+}
+
+func (h *dynamicCacheTestHarness) informerFor(gvr schema.GroupVersionResource) *clusterFake.MockGenericInformer {
+	informer := clusterFake.NewMockGenericInformer(h.controller)
+	h.informerFactory.EXPECT().
+		ForResource(gvr).
+		Return(informer)
+
+	return informer
+}
+
+func (h *dynamicCacheTestHarness) setupLister(gvr schema.GroupVersionResource, l cache.GenericLister) {
+	informer := h.informerFor(gvr)
+	informer.EXPECT().Lister().Return(l)
+}
+
+func (h *dynamicCacheTestHarness) mapResources(groupVersionKind schema.GroupVersionKind, resource schema.GroupVersionResource) {
+	h.client.EXPECT().
+		Resource(groupVersionKind.GroupKind()).
+		Return(resource, nil).
+		AnyTimes()
+}
+
+func (h *dynamicCacheTestHarness) setSynced(t *testing.T, c *DynamicCache, object runtime.Object) {
+	accessor, err := meta.Accessor(object)
 	require.NoError(t, err)
 
-	err = c.Unwatch(ctx, schema.GroupVersionKind{
-		Version: "v1",
-		Kind:    "Pod",
-	})
+	apiVersion, kind := object.GetObjectKind().GroupVersionKind().ToAPIVersionAndKind()
+
+	key := store.Key{
+		Namespace:  accessor.GetNamespace(),
+		APIVersion: apiVersion,
+		Kind:       kind,
+	}
+	c.informerSynced.setSynced(key, true)
+}
+
+func (h *dynamicCacheTestHarness) keyFromObject(t *testing.T, object runtime.Object) store.Key {
+	key, err := store.KeyFromObject(object)
 	require.NoError(t, err)
+	return key
 }


### PR DESCRIPTION
This change should speed up the initial views of octant. When informers for a resource haven't synced, Use the dynamic client's results instead.