### PR TITLE
add delete action for all objects in object printer

### DIFF
--- a/internal/modules/overview/printer/pod.go
+++ b/internal/modules/overview/printer/pod.go
@@ -22,8 +22,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 
 	"github.com/vmware/octant/internal/link"
-	"github.com/vmware/octant/internal/octant"
-	"github.com/vmware/octant/pkg/action"
 	"github.com/vmware/octant/pkg/store"
 	"github.com/vmware/octant/pkg/view/component"
 )
@@ -109,10 +107,6 @@ func podNode(pod *corev1.Pod, linkGenerator link.Interface) (component.Component
 func PodHandler(ctx context.Context, pod *corev1.Pod, options Options) (component.Component, error) {
 	o := NewObject(pod)
 	o.EnableEvents()
-
-	if err := setupPodActions(pod, o); err != nil {
-		return nil, err
-	}
 
 	ph, err := newPodHandler(pod, o)
 	if err != nil {
@@ -767,26 +761,6 @@ func (p *podHandler) Additional(options Options) error {
 	p.object.RegisterItems(itemDescriptors...)
 
 	return nil
-}
-
-func setupPodActions(pod *corev1.Pod, object ObjectInterface) error {
-	if pod.DeletionTimestamp == nil {
-		key, err := store.KeyFromObject(pod)
-		if err != nil {
-			return err
-		}
-
-		object.AddButton("Delete", action.CreatePayload(octant.ActionDeleteObject,
-			key.ToActionPayload()), deletePodConfirmation(pod))
-	}
-
-	return nil
-}
-
-func deletePodConfirmation(pod *corev1.Pod) component.ButtonOption {
-	confirmationTitle := "Delete pod"
-	confirmationBody := fmt.Sprintf("Are you sure you want to delete pod **%s**? This action is permanent and cannot be recovered.", pod.Name)
-	return component.WithButtonConfirmation(confirmationTitle, confirmationBody)
 }
 
 func addPodTableFilters(table *component.Table) {

--- a/internal/modules/overview/printer/pod_test.go
+++ b/internal/modules/overview/printer/pod_test.go
@@ -18,10 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/vmware/octant/internal/conversion"
-	"github.com/vmware/octant/internal/modules/overview/printer/fake"
-	"github.com/vmware/octant/internal/octant"
 	"github.com/vmware/octant/internal/testutil"
-	"github.com/vmware/octant/pkg/store"
 	"github.com/vmware/octant/pkg/view/component"
 )
 
@@ -414,39 +411,4 @@ func Test_printPodResources(t *testing.T) {
 	})
 
 	assert.Equal(t, expected, got)
-}
-
-func Test_setupPodActions(t *testing.T) {
-	controller := gomock.NewController(t)
-	defer controller.Finish()
-
-	objectInterface := fake.NewMockObjectInterface(controller)
-
-	pod := testutil.CreatePod("pod")
-	key, err := store.KeyFromObject(pod)
-	require.NoError(t, err)
-	payload := key.ToActionPayload()
-	payload["action"] = octant.ActionDeleteObject
-	objectInterface.EXPECT().
-		AddButton("Delete", payload, gomock.Any())
-
-	err = setupPodActions(pod, objectInterface)
-	require.NoError(t, err)
-}
-
-func Test_deletePodConfirmation(t *testing.T) {
-	pod := testutil.CreatePod("pod")
-	option := deletePodConfirmation(pod)
-
-	button := component.Button{}
-	option(&button)
-
-	expected := component.Button{
-		Confirmation: &component.Confirmation{
-			Title: "Delete pod",
-			Body:  "Are you sure you want to delete pod **pod**? This action is permanent and cannot be recovered.",
-		},
-	}
-
-	assert.Equal(t, expected, button)
 }


### PR DESCRIPTION
This change adds a delete button to all objects candled by the object printer. It also removes the custom pod delete button.