### PR TITLE
Reduce delay caused by retries in dynamic cache get

### DIFF
--- a/internal/modules/overview/objectvisitor/ingress_test.go
+++ b/internal/modules/overview/objectvisitor/ingress_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/vmware/octant/internal/modules/overview/objectvisitor"
@@ -26,7 +25,7 @@ func TestIngress_Visit(t *testing.T) {
 	service := testutil.CreateService("service")
 	q.EXPECT().
 		ServicesForIngress(gomock.Any(), object).
-		Return([]*corev1.Service{service}, nil)
+		Return(testutil.ToUnstructuredList(t, service), nil)
 
 	handler := fake.NewMockObjectHandler(controller)
 	handler.EXPECT().
@@ -64,7 +63,7 @@ func TestIngress_Visit_invalid_service_name(t *testing.T) {
 	q := queryerFake.NewMockQueryer(controller)
 	q.EXPECT().
 		ServicesForIngress(gomock.Any(), object).
-		Return([]*corev1.Service{}, nil)
+		Return(testutil.ToUnstructuredList(t), nil)
 
 	handler := fake.NewMockObjectHandler(controller)
 

--- a/internal/modules/overview/resourceviewer/resourceviewer.go
+++ b/internal/modules/overview/resourceviewer/resourceviewer.go
@@ -79,7 +79,9 @@ func (rv *ResourceViewer) Visit(ctx context.Context, object runtime.Object) (*co
 	logger.Debugf("starting resource viewer visit")
 
 	now := time.Now()
-	defer logger.With("elapsed", time.Since(now)).Debugf("ending resource viewer visit")
+	defer func() {
+		logger.With("elapsed", time.Since(now)).Debugf("ending resource viewer visit")
+	}()
 
 	handler, err := NewHandler(rv.dashConfig)
 	if err != nil {

--- a/internal/objectstore/access.go
+++ b/internal/objectstore/access.go
@@ -11,10 +11,11 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
-	"github.com/vmware/octant/internal/cluster"
-	"github.com/vmware/octant/pkg/store"
 	"go.opencensus.io/trace"
 	authorizationv1 "k8s.io/api/authorization/v1"
+
+	"github.com/vmware/octant/internal/cluster"
+	"github.com/vmware/octant/pkg/store"
 )
 
 type AccessError struct {

--- a/internal/queryer/queryer_test.go
+++ b/internal/queryer/queryer_test.go
@@ -19,6 +19,7 @@ import (
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -741,8 +742,10 @@ func TestCacheQueryer_ServicesForIngress(t *testing.T) {
 			require.NoError(t, err)
 
 			var got []string
-			for _, service := range services {
-				got = append(got, service.Name)
+			for _, service := range services.Items {
+				accessor, err := meta.Accessor(&service)
+				require.NoError(t, err)
+				got = append(got, accessor.GetName())
 			}
 			sort.Strings(got)
 			sort.Strings(tc.expected)


### PR DESCRIPTION
The delays incurred by retries in dynamic cache get were superfluous so they are removed. Instead, rely on the caller to handle the error received by the action.