### PR TITLE
Replace git.apache.org/trift.git with github.com/apache/thrift

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,3 +61,5 @@ require (
 )
 
 replace k8s.io/client-go => k8s.io/client-go v0.0.0-20190620085101-78d2af792bab
+
+replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,7 @@ github.com/akavel/rsrc v0.8.0 h1:zjWn7ukO9Kc5Q62DOJCcxGpXC18RawVtYAGdz2aLlfw=
 github.com/akavel/rsrc v0.8.0/go.mod h1:uLoCtb9J+EyAqh+26kdrTgmzRBFPGOolLWKpdxkKq+c=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/daaku/go.zipexe v1.0.0 h1:VSOgZtH418pH9L16hC/JrgSNJbbAL26pj7lmD1+CGdY=


### PR DESCRIPTION
When trying to build this project, I ran into problems with `make go-install` because one of the dependencies (Thrift) uses `git.apache.org`, which is [no longer online](https://status.apache.org/incidents/505pzrgbw9jh) and apparently [not the official repo](https://thrift.apache.org/developers#source-control).

The dependency comes from OpenCensus, and they updated it in https://github.com/census-instrumentation/opencensus-go/commit/3b8e2721f2c3c01fa1bf4a2e455874e7b8319cd7#diff-37aff102a57d3d7b797f152915a6dc16 and released in [v0.19.2](https://github.com/census-instrumentation/opencensus-go/releases/tag/v0.19.2); however, when trying to upgrade, I ran into [this](https://github.com/golang/go/issues/26904):

```shell
$ go get go.opencensus.io@v0.19.2
go: github.com/apache/thrift@v0.12.0 used for two different module paths (git.apache.org/thrift.git and github.com/apache/thrift)
```

I had some luck making it work by just manually find/replacing all references to the repo, but it felt a little hacky and still required this `replace` line you see here. I have a feeling that that was happening because `go get` was still trying to pull from master of this repo. I'm still somewhat new to `go mod`, so I'm open to other suggestions.

So, to keep things simple, I just made the `replace` change in this PR, and then we can probably follow up with an upgrade of OpenCensus.