### PR TITLE
Fix sample plugin path with removed content prefix

### DIFF
--- a/changelogs/unreleased/305-dotNomad
+++ b/changelogs/unreleased/305-dotNomad
@@ -1,0 +1,1 @@
+Fix sample plugin path with removed content prefix

--- a/cmd/octant-sample-plugin/main.go
+++ b/cmd/octant-sample-plugin/main.go
@@ -181,7 +181,7 @@ func initRoutes(router *service.Router) {
 		return cardList
 	}
 
-	router.HandleFunc("/*", func(request *service.Request) (component.ContentResponse, error) {
+	router.HandleFunc("*", func(request *service.Request) (component.ContentResponse, error) {
 		// For each page, generate two tabs with a some content.
 		component1 := gen("Tab 1", "tab1", request.Path)
 		component2 := gen("Tab 2", "tab2", request.Path)


### PR DESCRIPTION
The sample plugin's base page at `http://127.0.0.1:7777/#/plugin-name` appears blank with the change that removed the content prefix from paths (#284 I believe).