### PR TITLE
CLA Test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## CLA
 
-New contributors will need to sign a contributor license agreement before code changes can be merged. Follow the instructions given by `vmwclabot` after opening a pull request.
+New contributors will need to sign a [contributor license agreement](https://cla.vmware.com) before code changes can be merged. Follow the instructions given by `vmwclabot` after opening a pull request.
 
 ## CHANGELOG 
 


### PR DESCRIPTION
Hi! One of our engineers has a questions about signing the VMWare CLA to contribute to this project, but it seems like the only way to get a copy of the CLA text that they/we would be asked to sign is to create a PR. So, uh, here's a PR!

(We've found it useful to have the text that people will be asked to sign available publicly ahead of time for review by their legal team, in our case at https://cla.salesforce.com/sign-cla; might be worth considering?)